### PR TITLE
Expose close frame to users for close handling

### DIFF
--- a/src/native.rs
+++ b/src/native.rs
@@ -1975,8 +1975,8 @@ impl WebSocket {
                 self.on_ping(frame);
                 Ok(None)
             }
-            OpCode::Close => match self.on_close(frame) {
-                Ok(_) => Ok(None),
+            OpCode::Close => match self.on_close(&frame) {
+                Ok(_) => Ok(Some(frame)),
                 Err(err) => Err(err),
             },
             OpCode::Continuation => unreachable!(),
@@ -1988,7 +1988,7 @@ impl WebSocket {
             .push_back(FrameView::pong(frame.payload));
     }
 
-    fn on_close(&mut self, frame: FrameView) -> Result<()> {
+    fn on_close(&mut self, frame: &FrameView) -> Result<()> {
         match frame.payload.len() {
             0 => {}
             1 => return Err(WebSocketError::InvalidCloseFrame),


### PR DESCRIPTION
Previously, the WebSocket close frame (FrameView) was not propagated to users, making it difficult to inspect or log the reason for closure.

This change exposes the close frame, enabling users to handle it explicitly, for example, to extract and log the close reason code and message for debugging or monitoring purposes.

### WebSocket close frame handling:

* Updated the `on_close` method to take a reference to `FrameView` (`&FrameView`) instead of consuming it, ensuring the frame is not moved and can be reused elsewhere.
* Adjusted the `OpCode::Close` match arm to return `Some(frame)` when the `on_close` method succeeds, allowing the frame to be propagated further if needed.