### PR TITLE
[WIP] Relax websocket extensions parser

### DIFF
--- a/src/compression.rs
+++ b/src/compression.rs
@@ -180,7 +180,7 @@ impl WebSocketExtensions {
                     opt(preceded(tag("="), opt(digit1))),
                 ),
             ),
-        )(input)
+        )(input.trim())
         .map(|(key, (key2, value))| (key, (key2, value.flatten())))
     }
 }


### PR DESCRIPTION
The websocket extensions parser is relaxed to allow whitespace around parameters.
This is not strictly compliant with the websocket RFC, but it is what one websocket server sends and we need to deal with it.

The library sends the following header in the request: 
```
"sec-websocket-extensions": "permessage-deflate; server_no_context_takeover"
```

And the websocket server responds with:
```
"sec-websocket-extensions": "permessage-deflate ; server_no_context_takeover"
```
having a space before the semicolon. This is not compliant with the RFC, it caused the websocket extension parser to return an error when parsing the response.