### PR TITLE
Update license in `Cargo.toml` to match LICENSE file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Dario <dario@infinitefieldtrading.com>"]
 description = "Yet another websocket library. But a fast, secure WebSocket implementation with RFC 6455 compliance and compression support"
 documentation = "https://docs.rs/yawc"
 repository = "https://github.com/infinitefield/yawc"
-license = "LGPL-3.0-or-later"
+license = "MPL-2.0"
 keywords = ["websocket", "websockets", "ws", "networking", "wasm"]
 categories = [
     "network-programming",


### PR DESCRIPTION
This PR updates the `license` field in the `Cargo.toml` to match the license in the `LICENSE` file after https://github.com/infinitefield/yawc/commit/c868344b9a9414d4ed5c3e4dc0caf0793a89ad49.