### PR TITLE
fix: stop the inflate loop spinning on a final deflate block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ tags*
 !/benches/README.md
 !/benches/load_test.c
 !/benches/Makefile
+
+# cargo-fuzz
+fuzz/Cargo.lock
+fuzz/corpus/
+fuzz/artifacts/
+fuzz/coverage/
+fuzz/target/

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -158,3 +158,34 @@ dependencies = [
 
 [tasks.default]
 alias = "ci"
+
+# ------------------------------------------------------------------------------
+# Fuzzing
+# ------------------------------------------------------------------------------
+#
+# Coverage-guided targets, see fuzz/README.md. These need nightly and
+# `cargo install cargo-fuzz`, so they are not part of the `ci` task. The seeded
+# `test_fuzz_*` tests in src/compression.rs cover the same properties on every run.
+#
+# `-timeout` makes libFuzzer report an input that stops making progress as a hang,
+# which is the failure mode of issue #40.
+
+[tasks.fuzz-frame]
+description = "Fuzz the frame decoder for 5 minutes"
+command = "cargo"
+args = [
+    "+nightly", "fuzz", "run", "frame_decode", "--fuzz-dir", "fuzz", "--",
+    "-max_total_time=300", "-timeout=15",
+]
+
+[tasks.fuzz-websocket]
+description = "Fuzz the websocket read path for 5 minutes"
+command = "cargo"
+args = [
+    "+nightly", "fuzz", "run", "websocket_read", "--fuzz-dir", "fuzz", "--",
+    "-max_total_time=300", "-timeout=15",
+]
+
+[tasks.fuzz]
+description = "Run all fuzz targets"
+dependencies = ["fuzz-frame", "fuzz-websocket"]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,35 @@
+[package]
+name = "yawc-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+tokio = { version = "1", features = ["io-util", "macros", "rt"] }
+tokio-util = { version = "0.7", features = ["codec"] }
+bytes = "1"
+
+[dependencies.yawc]
+path = ".."
+features = ["zlib"]
+
+[[bin]]
+name = "frame_decode"
+path = "fuzz_targets/frame_decode.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "websocket_read"
+path = "fuzz_targets/websocket_read.rs"
+test = false
+doc = false
+bench = false
+
+[workspace]
+members = ["."]

--- a/fuzz/README.md
+++ b/fuzz/README.md
@@ -1,0 +1,46 @@
+# Fuzzing
+
+Coverage-guided fuzz targets, run with [cargo-fuzz]. They need a nightly toolchain,
+so they are not part of `cargo make ci`.
+
+```sh
+cargo install cargo-fuzz
+cargo make fuzz             # both targets, 5 minutes each
+cargo make fuzz-frame       # or one at a time
+cargo make fuzz-websocket
+```
+
+To run one directly, with your own limits:
+
+```sh
+cargo +nightly fuzz run websocket_read --fuzz-dir fuzz -- -max_total_time=600 -timeout=15
+```
+
+## Targets
+
+- `frame_decode`: arbitrary bytes into the frame decoder, as both roles.
+- `websocket_read`: arbitrary bytes into a `WebSocket` with permessage-deflate
+  negotiated. Covers frame decoding, fragment assembly, decompression and UTF-8
+  validation.
+
+## What counts as a failure
+
+Panics, but also hangs. `-timeout` makes libFuzzer report an input that stops making
+progress, which is how [issue #40] would have been caught: a deflate stream ending in
+a final block spun the inflate loop forever instead of returning.
+
+Keep `-timeout` well above a normal run (a few milliseconds) so only real hangs trip
+it. Reproduce a saved crash or hang with:
+
+```sh
+cargo +nightly fuzz run websocket_read --fuzz-dir fuzz fuzz/artifacts/websocket_read/<file>
+```
+
+The corpus under `fuzz/corpus/` is generated, not checked in.
+
+There are also seeded, deterministic fuzz tests in `src/compression.rs`
+(`test_fuzz_*`) that run as part of the normal suite. They cover the same properties
+on every CI run, without nightly. This directory is for the deeper, longer runs.
+
+[cargo-fuzz]: https://rust-fuzz.github.io/book/cargo-fuzz.html
+[issue #40]: https://github.com/infinitefield/yawc/issues/40

--- a/fuzz/fuzz_targets/frame_decode.rs
+++ b/fuzz/fuzz_targets/frame_decode.rs
@@ -1,0 +1,29 @@
+#![no_main]
+
+//! Feeds arbitrary bytes to the frame decoder.
+//!
+//! The decoder must either produce frames or return an error. It must never panic,
+//! and it must never stop making progress: libFuzzer reports a non-terminating input
+//! as a hang.
+
+use bytes::BytesMut;
+use libfuzzer_sys::fuzz_target;
+use tokio_util::codec::Decoder as _;
+use yawc::codec::Decoder;
+use yawc::Role;
+
+fuzz_target!(|data: &[u8]| {
+    // Both roles: a server rejects unmasked frames, a client rejects masked ones,
+    // so they take different paths through the decoder.
+    for role in [Role::Server, Role::Client] {
+        let mut decoder = Decoder::new(role, 1 << 20);
+        let mut buf = BytesMut::from(data);
+
+        // Drain until the decoder errors or asks for more bytes.
+        while let Ok(Some(_frame)) = decoder.decode(&mut buf) {
+            if buf.is_empty() {
+                break;
+            }
+        }
+    }
+});

--- a/fuzz/fuzz_targets/websocket_read.rs
+++ b/fuzz/fuzz_targets/websocket_read.rs
@@ -1,0 +1,66 @@
+#![no_main]
+
+//! Feeds arbitrary bytes to a `WebSocket` as if they came from a peer, with
+//! permessage-deflate negotiated.
+//!
+//! This covers the whole read path: frame decoding, fragment assembly, decompression
+//! and UTF-8 validation. Reading must always terminate, either with frames or with an
+//! error. Issue #40 was a hang in this path, where a deflate stream ending in a final
+//! block spun the inflate loop forever on the trailing bytes.
+
+use libfuzzer_sys::fuzz_target;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use yawc::{Options, WebSocket};
+
+/// Response headers that get the client past the handshake with compression enabled.
+/// `Sec-WebSocket-Accept` is not validated, so a fixed value is fine here.
+const HANDSHAKE: &[u8] = b"HTTP/1.1 101 Switching Protocols\r\n\
+    upgrade: websocket\r\n\
+    connection: upgrade\r\n\
+    sec-websocket-accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\
+    sec-websocket-extensions: permessage-deflate\r\n\
+    \r\n";
+
+fuzz_target!(|data: &[u8]| {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("runtime");
+
+    runtime.block_on(async move {
+        let (client_io, mut peer) = tokio::io::duplex(64 * 1024);
+
+        // The peer reads the request, writes the handshake, then the fuzz input as the
+        // frame stream, then hangs up. Reading first matters: hyper rejects a response
+        // that arrives before it has sent its request, which would fail every run
+        // before the input is ever parsed. Writing concurrently keeps a large input
+        // from filling the duplex.
+        let data = data.to_vec();
+        tokio::spawn(async move {
+            let mut request = Vec::new();
+            let mut byte = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                match peer.read(&mut byte).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => request.push(byte[0]),
+                }
+            }
+
+            if peer.write_all(HANDSHAKE).await.is_err() {
+                return;
+            }
+            let _ = peer.write_all(&data).await;
+            let _ = peer.shutdown().await;
+        });
+
+        let url = "ws://localhost/".parse().expect("url");
+        let options = Options::default().with_compression_level(Default::default());
+
+        let Ok(mut ws) = WebSocket::handshake(url, client_io, options).await else {
+            return;
+        };
+
+        // Read until the connection errors out or the peer's bytes run out.
+        while ws.next_frame().await.is_ok() {}
+    });
+});

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -11,7 +11,7 @@ use nom::{
     IResult, Parser,
 };
 
-use crate::{CompressionLevel, DeflateOptions};
+use crate::{CompressionLevel, DeflateOptions, Role, WebSocketError};
 
 static PERMESSAGE_DEFLATE: &str = "permessage-deflate";
 
@@ -209,70 +209,123 @@ impl std::str::FromStr for WebSocketExtensions {
         Self::parse(input).map_err(|err| err.to_string())
     }
 }
-/// A compressor for handling WebSocket payload compression, supporting both contextual and no-context-takeover modes.
+/// Deflate settings for one direction of a connection.
 ///
-/// `Compressor` is used to compress WebSocket message payloads, optimizing data transmission.
-/// It provides flexibility with different configurations, such as specifying compression level,
-/// window size (when using `zlib`), and no-context-takeover mode.
-pub struct Compressor {
-    compressor_type: CompressorType,
+/// Which of the negotiated `client_*`/`server_*` values end up here depends on the role,
+/// and that mapping is applied once in [`CompressionConfig::resolve`], so nothing
+/// downstream has to reason about it again.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct HalfConfig {
+    /// Reset the dictionary after every message.
+    pub(crate) no_context_takeover: bool,
+    /// LZ77 window size, already clamped to the range deflate accepts.
+    pub(crate) window_bits: Option<u8>,
 }
 
-/// Enum representing different types of compression strategies:
-/// - `Contextual`: Maintains compression context across frames.
-/// - `NoContextTakeover`: Resets the compression dictionary after each frame, reducing memory usage at the cost of compression efficiency.
-enum CompressorType {
-    Contextual(Deflate),
-    NoContextTakeover(Deflate),
+/// The window sizes deflate accepts. Peers may negotiate values outside this range, and
+/// the RFC 7692 lower bound of 8 is not usable with every backend.
+const WINDOW_BITS: std::ops::RangeInclusive<u8> = 9..=15;
+
+/// Resolved permessage-deflate configuration for a connection.
+///
+/// Built once at handshake time from the negotiated extension parameters, with the role
+/// already applied, so the read and write paths just use `incoming`/`outgoing`.
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct CompressionConfig {
+    level: CompressionLevel,
+    /// Settings for the direction we compress.
+    outgoing: HalfConfig,
+    /// Settings for the direction we decompress.
+    incoming: HalfConfig,
+    /// Send already-compressed payloads without deflating them again.
+    pub(crate) skip_incompressible: bool,
+}
+
+impl CompressionConfig {
+    /// Resolves the negotiated extension parameters into per-direction settings.
+    ///
+    /// Returns `Ok(None)` when permessage-deflate was not negotiated.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`WebSocketError::CompressionNotSupported`] when the peer negotiated the
+    /// extension but this side never offered compression. For a client that is the
+    /// RFC 6455, Section 4.1 case of a server returning an extension the client did not
+    /// ask for, which the client must fail on.
+    pub(crate) fn resolve(
+        extensions: Option<&WebSocketExtensions>,
+        level: Option<CompressionLevel>,
+        skip_incompressible: bool,
+        role: Role,
+    ) -> crate::Result<Option<Self>> {
+        let Some(extensions) = extensions else {
+            return Ok(None);
+        };
+
+        let Some(level) = level else {
+            return Err(WebSocketError::CompressionNotSupported);
+        };
+
+        let clamp = |bits: Option<Option<u8>>| {
+            bits.flatten()
+                .map(|bits| bits.clamp(*WINDOW_BITS.start(), *WINDOW_BITS.end()))
+        };
+
+        let client = HalfConfig {
+            no_context_takeover: extensions.client_no_context_takeover,
+            window_bits: clamp(extensions.client_max_window_bits),
+        };
+        let server = HalfConfig {
+            no_context_takeover: extensions.server_no_context_takeover,
+            window_bits: clamp(extensions.server_max_window_bits),
+        };
+
+        // A peer compresses with its own settings and decompresses with the other side's.
+        let (outgoing, incoming) = match role {
+            Role::Client => (client, server),
+            Role::Server => (server, client),
+        };
+
+        Ok(Some(Self {
+            level,
+            outgoing,
+            incoming,
+            skip_incompressible,
+        }))
+    }
+
+    /// Builds the compressor for the direction this side writes.
+    pub(crate) fn compressor(&self) -> Compressor {
+        Compressor::new(self.level, self.outgoing)
+    }
+
+    /// Builds the decompressor for the direction this side reads.
+    pub(crate) fn decompressor(&self) -> Decompressor {
+        Decompressor::new(self.incoming)
+    }
+}
+
+/// Compresses WebSocket payloads with permessage-deflate.
+///
+/// In no-context-takeover mode the dictionary is reset after each message, lowering
+/// memory use at the cost of compression ratio.
+pub struct Compressor {
+    deflate: Deflate,
+    no_context_takeover: bool,
 }
 
 impl Compressor {
-    /// Creates a new compressor with the specified compression level.
-    ///
-    /// The compressor will maintain the compression context across frames, improving efficiency.
-    ///
-    /// # Parameters
-    /// - `level`: The level of compression to be applied.
-    ///
-    /// # Returns
-    /// A `Compressor` instance in contextual mode.
-    pub fn new(level: CompressionLevel) -> Self {
+    /// Creates a compressor for one direction of a connection.
+    pub(crate) fn new(level: CompressionLevel, config: HalfConfig) -> Self {
         Self {
-            compressor_type: CompressorType::Contextual(Deflate::new(level)),
-        }
-    }
-
-    /// Creates a new compressor with a specific window size for LZ77, available when `zlib` is enabled.
-    ///
-    /// # Parameters
-    /// - `level`: The level of compression.
-    /// - `window_bits`: The number of bits for the LZ77 compression window.
-    ///
-    /// # Returns
-    /// A `Compressor` instance configured with the specified window size.
-    #[cfg(feature = "zlib")]
-    pub fn new_with_window_bits(level: CompressionLevel, window_bits: u8) -> Self {
-        Self {
-            compressor_type: CompressorType::Contextual(Deflate::new_with_window_bits(
-                level,
-                window_bits,
-            )),
-        }
-    }
-
-    /// Creates a new compressor in no-context-takeover mode.
-    ///
-    /// In no-context-takeover mode, the compressor resets its dictionary after each frame,
-    /// lowering memory usage at the cost of compression efficiency.
-    ///
-    /// # Parameters
-    /// - `level`: The level of compression.
-    ///
-    /// # Returns
-    /// A `Compressor` instance in no-context-takeover mode.
-    pub fn no_context_takeover(level: CompressionLevel) -> Self {
-        Self {
-            compressor_type: CompressorType::NoContextTakeover(Deflate::new(level)),
+            deflate: match config.window_bits {
+                #[cfg(feature = "zlib")]
+                Some(window_bits) => Deflate::new_with_window_bits(level, window_bits),
+                #[cfg(not(feature = "zlib"))]
+                Some(_) => Deflate::new(level),
+                None => Deflate::new(level),
+            },
+            no_context_takeover: config.no_context_takeover,
         }
     }
 
@@ -281,16 +334,12 @@ impl Compressor {
     /// # Parameters
     /// - `input`: The data slice to compress.
     /// - `flush`: Whether to flush the compressor (typically true for final frames).
-    ///
-    /// # Returns
-    /// A `BytesMut` containing the compressed data, or an `io::Error` if compression fails.
     pub fn compress(&mut self, input: &[u8], flush: bool) -> io::Result<Bytes> {
-        match &mut self.compressor_type {
-            CompressorType::Contextual(compressor) => compressor.compress(input, flush),
-            CompressorType::NoContextTakeover(compressor) => {
-                compressor.compress_no_context(input, flush)
-            }
+        let res = self.deflate.compress(input, flush);
+        if flush && self.no_context_takeover {
+            self.deflate.reset();
         }
+        res
     }
 }
 
@@ -323,13 +372,9 @@ impl Deflate {
         }
     }
 
-    /// Compresses input data with no context takeover, resetting the compression dictionary before each compression.
-    fn compress_no_context(&mut self, input: &[u8], flush: bool) -> io::Result<Bytes> {
-        let res = self.compress(input, flush);
-        if flush {
-            self.compress.reset(); // Reset dictionary for no-context takeover
-        }
-        res
+    /// Resets the compression dictionary, for no-context-takeover mode.
+    fn reset(&mut self) {
+        self.compress.reset();
     }
 
     /// Compresses input data while maintaining compression context across frames.
@@ -416,6 +461,58 @@ fn inflate_error(err: DecompressError) -> io::Error {
     )
 }
 
+/// Payloads below this size are always compressed: the sampling is not reliable on a
+/// short payload, and the work saved would be negligible anyway.
+pub(crate) const INCOMPRESSIBLE_MIN_LEN: usize = 1024;
+
+/// Number of bytes sampled when estimating whether a payload is already compressed.
+const ENTROPY_SAMPLE: usize = 2048;
+
+/// Shannon entropy above which a payload is treated as already compressed.
+///
+/// Compressed and encrypted data sits at ~7.9-8.0 bits per byte; text, JSON and most
+/// binary formats sit well below 7. The gap is wide, so the exact cutoff is not
+/// delicate.
+const INCOMPRESSIBLE_ENTROPY: f32 = 7.5;
+
+/// Estimates whether `data` is already compressed, and so not worth deflating.
+///
+/// Deflating already-compressed input is the most expensive case there is and makes the
+/// payload larger, so it is worth a cheap check first. This samples evenly across the
+/// payload rather than reading a prefix, since compressed formats often start with a
+/// low-entropy header.
+///
+/// Being wrong is not a correctness problem in either direction: a false positive sends
+/// a compressible message uncompressed, a false negative wastes the work it would have
+/// spent anyway.
+pub(crate) fn looks_incompressible(data: &[u8]) -> bool {
+    let mut histogram = [0u32; 256];
+    let mut sampled = 0u32;
+
+    // Stride so the sample spans the whole payload.
+    let stride = (data.len() / ENTROPY_SAMPLE).max(1);
+    for byte in data.iter().step_by(stride).take(ENTROPY_SAMPLE) {
+        histogram[*byte as usize] += 1;
+        sampled += 1;
+    }
+
+    if sampled == 0 {
+        return false;
+    }
+
+    let total = sampled as f32;
+    let entropy: f32 = histogram
+        .iter()
+        .filter(|count| **count > 0)
+        .map(|count| {
+            let p = *count as f32 / total;
+            -p * p.log2()
+        })
+        .sum();
+
+    entropy >= INCOMPRESSIBLE_ENTROPY
+}
+
 /// Returns a mutable slice to the next available chunk of memory in the BytesMut buffer.
 ///
 /// This function ensures that there's always at least 1024 bytes available in the returning byte slice.
@@ -429,129 +526,41 @@ fn chunk(output: &mut BytesMut) -> &mut [u8] {
     unsafe { &mut *(uninitbuf as *mut [std::mem::MaybeUninit<u8>] as *mut [u8]) }
 }
 
-/// A decompressor for handling WebSocket payload decompression.
+/// Decompresses WebSocket payloads compressed with permessage-deflate.
 ///
-/// The `Decompressor` type provides functionality for decompressing WebSocket messages that were
-/// compressed using the permessage-deflate extension. It supports two modes of operation:
-///
-/// - Contextual mode: The decompression context (dictionary) is maintained across multiple frames,
-///   providing better compression ratios for related data.
-///
-/// - No-context-takeover mode: The decompression context is reset after each frame, trading
-///   compression efficiency for reduced memory usage.
-///
+/// In no-context-takeover mode the dictionary is reset after each message, matching a
+/// peer that compresses the same way.
 pub struct Decompressor {
-    decompressor_type: DecompressorType,
-}
-
-impl Default for Decompressor {
-    /// Creates a new decompressor in contextual mode by default.
-    ///
-    /// This is equivalent to calling [`Decompressor::new()`].
-    ///
-    /// # Returns
-    ///
-    /// Returns a new `Decompressor` instance that maintains compression context across frames.
-    fn default() -> Self {
-        Self {
-            decompressor_type: DecompressorType::Contextual(Default::default()),
-        }
-    }
-}
-
-/// The type of decompression strategy to use.
-///
-/// This enum determines how the decompressor handles the compression dictionary between frames:
-/// - `Contextual`: Maintains the dictionary across multiple frames for better compression
-/// - `NoContextTakeover`: Resets the dictionary after each frame to reduce memory usage
-enum DecompressorType {
-    /// Retains decompression context across frames for better compression ratios.
-    Contextual(Inflate),
-    /// Resets decompression context after each frame to reduce memory usage.
-    NoContextTakeover(Inflate),
+    inflate: Inflate,
+    no_context_takeover: bool,
 }
 
 impl Decompressor {
-    /// Creates a new `Decompressor` in contextual mode.
-    ///
-    /// The created decompressor will maintain its internal dictionary state between frames,
-    /// potentially providing better compression ratios for related data across frames.
-    ///
-    /// # Returns
-    ///
-    /// Returns a new `Decompressor` instance that uses contextual decompression.
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    /// Creates a new `Decompressor` with specific LZ77 window bits.
-    ///
-    /// This constructor allows fine-tuning of the decompression window size when using
-    /// the `zlib` feature. A larger window size generally provides better compression
-    /// but requires more memory.
-    ///
-    /// # Parameters
-    ///
-    /// * `window_bits` - Number of bits to use for the LZ77 sliding window (9-15)
-    ///
-    /// # Returns
-    ///
-    /// Returns a new `Decompressor` configured with the specified window size.
-    ///
-    /// # Features
-    ///
-    /// This function is only available when compiled with the `zlib` feature enabled.
-    #[cfg(feature = "zlib")]
-    pub fn new_with_window_bits(window_bits: u8) -> Self {
+    /// Creates a decompressor for one direction of a connection.
+    pub(crate) fn new(config: HalfConfig) -> Self {
         Self {
-            decompressor_type: DecompressorType::Contextual(Inflate::new_with_window_bits(
-                window_bits,
-            )),
-        }
-    }
-
-    /// Creates a new `Decompressor` in no-context-takeover mode.
-    ///
-    /// In no-context-takeover mode, the decompression dictionary is reset after processing
-    /// each frame. This reduces memory usage at the cost of potentially lower compression
-    /// ratios, since each frame is decompressed independently.
-    ///
-    /// # Returns
-    ///
-    /// Returns a new `Decompressor` instance that resets its context after each frame.
-    pub fn no_context_takeover() -> Self {
-        Self {
-            decompressor_type: DecompressorType::NoContextTakeover(Default::default()),
+            inflate: match config.window_bits {
+                #[cfg(feature = "zlib")]
+                Some(window_bits) => Inflate::new_with_window_bits(window_bits),
+                #[cfg(not(feature = "zlib"))]
+                Some(_) => Inflate::default(),
+                None => Inflate::default(),
+            },
+            no_context_takeover: config.no_context_takeover,
         }
     }
 
     /// Decompresses a compressed data frame.
     ///
-    /// This method decompresses the provided input data according to the configured mode
-    /// (contextual or no-context-takeover). When `stream_end` is true, this indicates the
-    /// final frame in a message, which triggers special handling required by the WebSocket
-    /// permessage-deflate extension.
-    ///
-    /// # Parameters
-    ///
-    /// * `input` - The compressed data bytes to decompress
-    /// * `stream_end` - Boolean flag indicating if this is the final frame in a message
-    ///
-    /// # Returns
-    ///
-    /// * `Ok(Some(BytesMut))` - Successfully decompressed data
-    /// * `Ok(None)` - More input needed to complete decompression
-    /// * `Err(io::Error)` - Decompression failed due to invalid/corrupt data
-    ///
+    /// `stream_end` marks the final frame of a message, which triggers the handling
+    /// permessage-deflate requires (the 4-byte suffix, and the dictionary reset in
+    /// no-context-takeover mode).
     pub fn decompress(&mut self, input: &[u8], stream_end: bool) -> io::Result<Bytes> {
-        match &mut self.decompressor_type {
-            DecompressorType::Contextual(decompressor) => {
-                decompressor.decompress(input, stream_end)
-            }
-            DecompressorType::NoContextTakeover(decompressor) => {
-                decompressor.decompress_no_context(input, stream_end)
-            }
+        let res = self.inflate.decompress(input, stream_end);
+        if stream_end && self.no_context_takeover {
+            self.inflate.reset();
         }
+        res
     }
 }
 
@@ -563,6 +572,11 @@ impl Decompressor {
 struct Inflate {
     output: BytesMut,
     decompress: flate2::Decompress,
+    /// Set when the peer terminated the deflate stream with a final block (BFINAL=1).
+    ///
+    /// Once that happens the inflater cannot consume any more input, so the remaining
+    /// bytes are dropped and the context is reset before the next message.
+    stream_ended: bool,
 }
 
 impl Default for Inflate {
@@ -571,6 +585,7 @@ impl Default for Inflate {
         Self {
             output: BytesMut::with_capacity(1024),
             decompress: flate2::Decompress::new(false),
+            stream_ended: false,
         }
     }
 }
@@ -591,16 +606,14 @@ impl Inflate {
         Self {
             output: BytesMut::with_capacity(1024),
             decompress: flate2::Decompress::new_with_window_bits(false, window_bits),
+            stream_ended: false,
         }
     }
 
-    /// Decompresses input data in no-context-takeover mode, resetting the decompression context before each call.
-    fn decompress_no_context(&mut self, input: &[u8], stream_end: bool) -> io::Result<Bytes> {
-        let res = self.decompress(input, stream_end);
-        if stream_end {
-            self.decompress.reset(false); // Reset the context for no-context takeover
-        }
-        res
+    /// Resets the decompression dictionary, for no-context-takeover mode.
+    fn reset(&mut self) {
+        self.decompress.reset(false);
+        self.stream_ended = false;
     }
 
     /// Decompresses input data while maintaining decompression context across frames.
@@ -608,9 +621,23 @@ impl Inflate {
         self.write(input)?;
 
         if stream_end {
-            // Add the required 4-byte suffix as per RFC 7692, Section 7.2.2
-            self.write(&[0x0, 0x0, 0xff, 0xff])?;
-            self.flush()
+            // Add the required 4-byte suffix as per RFC 7692, Section 7.2.2.
+            // A peer that already closed the stream with a final block does not need it,
+            // and feeding it would be rejected by the inflater anyway.
+            if !self.stream_ended {
+                self.write(&[0x0, 0x0, 0xff, 0xff])?;
+            }
+
+            let out = self.flush()?;
+
+            // The stream is unusable once the peer sent a final block, so start fresh.
+            // Such a peer is effectively running with no context takeover.
+            if self.stream_ended {
+                self.decompress.reset(false);
+                self.stream_ended = false;
+            }
+
+            Ok(out)
         } else {
             Ok(self.output.split().freeze())
         }
@@ -620,6 +647,7 @@ impl Inflate {
     fn write(&mut self, mut input: &[u8]) -> io::Result<()> {
         let output = &mut self.output;
         let decompressor = &mut self.decompress;
+        let mut stream_ended = false;
 
         while !input.is_empty() {
             let dst = chunk(output);
@@ -637,7 +665,13 @@ impl Inflate {
             input = &input[consumed..];
 
             match status {
-                Ok(Status::Ok | Status::BufError | Status::StreamEnd) => {}
+                // The peer closed the deflate stream with a final block. Nothing after it can
+                // be consumed, so stop instead of looping forever over the leftover bytes.
+                Ok(Status::StreamEnd) => {
+                    stream_ended = true;
+                    break;
+                }
+                Ok(Status::Ok | Status::BufError) => {}
                 Err(..) => {
                     return Err(io::Error::new(
                         io::ErrorKind::InvalidInput,
@@ -645,7 +679,18 @@ impl Inflate {
                     ))
                 }
             }
+
+            // Guard against any other state where the inflater makes no progress:
+            // without this the loop would spin on the CPU until the process is killed.
+            if consumed == 0 && read == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "deflate stream made no progress",
+                ));
+            }
         }
+
+        self.stream_ended |= stream_ended;
 
         Ok(())
     }
@@ -689,7 +734,11 @@ impl Inflate {
 mod tests {
     use flate2::Compression;
 
-    use crate::compression::{Compressor, Decompressor, Deflate, Inflate};
+    use crate::compression::{
+        looks_incompressible, CompressionConfig, Compressor, Decompressor, Deflate, HalfConfig,
+        Inflate, INCOMPRESSIBLE_MIN_LEN, WINDOW_BITS,
+    };
+    use crate::{CompressionLevel, Role, WebSocketError};
 
     use super::WebSocketExtensions;
 
@@ -754,9 +803,8 @@ mod tests {
     fn test_compress_no_context() {
         let mut deflate = Deflate::new(Compression::default());
         let data = b"test data";
-        let compressed = deflate
-            .compress_no_context(data, true)
-            .expect("Compression failed");
+        let compressed = deflate.compress(data, true).expect("Compression failed");
+        deflate.reset();
         assert!(!compressed.is_empty());
     }
 
@@ -848,20 +896,25 @@ mod tests {
     fn test_decompress_no_context() {
         let mut deflate = Deflate::new(Compression::default());
         let data = b"test data";
-        let compressed = deflate
-            .compress_no_context(data, true)
-            .expect("Compression failed");
+        let compressed = deflate.compress(data, true).expect("Compression failed");
+        deflate.reset();
 
         let mut inflate = Inflate::default();
         let decompressed = inflate
-            .decompress_no_context(&compressed, true)
+            .decompress(&compressed, true)
             .expect("Decompression failed");
         assert_eq!(decompressed.as_ref(), &data[..]);
     }
 
     #[test]
     fn test_compressor_no_context_takeover() {
-        let mut compressor = Compressor::no_context_takeover(Compression::default());
+        let mut compressor = Compressor::new(
+            Compression::default(),
+            HalfConfig {
+                no_context_takeover: true,
+                window_bits: None,
+            },
+        );
         let data = b"sample data";
         let compressed = compressor.compress(data, true).expect("Compression failed");
         assert!(!compressed.is_empty());
@@ -869,11 +922,20 @@ mod tests {
 
     #[test]
     fn test_decompressor_no_context_takeover() {
-        let mut compressor = Compressor::no_context_takeover(Compression::default());
+        let mut compressor = Compressor::new(
+            Compression::default(),
+            HalfConfig {
+                no_context_takeover: true,
+                window_bits: None,
+            },
+        );
         let data = b"sample data";
         let compressed = compressor.compress(data, true).expect("Compression failed");
 
-        let mut decompressor = Decompressor::no_context_takeover();
+        let mut decompressor = Decompressor::new(HalfConfig {
+            no_context_takeover: true,
+            window_bits: None,
+        });
         let decompressed = decompressor
             .decompress(&compressed, true)
             .expect("Decompression failed");
@@ -883,12 +945,12 @@ mod tests {
     #[test]
     fn test_large_data_compression_and_decompression() {
         let large_data = vec![1u8; 1024 * 1024]; // 1 MB of data
-        let mut compressor = Compressor::new(Compression::default());
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
         let compressed = compressor
             .compress(&large_data, true)
             .expect("Compression failed");
 
-        let mut decompressor = Decompressor::new();
+        let mut decompressor = Decompressor::new(HalfConfig::default());
         let decompressed = decompressor
             .decompress(&compressed, true)
             .expect("Decompression failed");
@@ -912,8 +974,8 @@ mod tests {
         let csv_like_data = "timestamp,user_id,action,data,more_data,even_more_data,field1,field2,field3,field4,field5,field6,field7,field8,field9,field10"
             .repeat(100); // Create a long repeated string similar to CSV data
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         // Test multiple sequential compressions and decompressions
         for i in 1..=10 {
@@ -955,8 +1017,17 @@ mod tests {
         let csv_like_data = "timestamp,user_id,action,data,more_data,even_more_data,field1,field2,field3,field4,field5,field6,field7,field8,field9,field10"
         .repeat(n);
 
-        let mut compressor = Compressor::no_context_takeover(Compression::default());
-        let mut decompressor = Decompressor::no_context_takeover();
+        let mut compressor = Compressor::new(
+            Compression::default(),
+            HalfConfig {
+                no_context_takeover: true,
+                window_bits: None,
+            },
+        );
+        let mut decompressor = Decompressor::new(HalfConfig {
+            no_context_takeover: true,
+            window_bits: None,
+        });
 
         for i in 1..=10 {
             println!("Processing no-context message {i}");
@@ -996,8 +1067,8 @@ mod tests {
         let csv_like_data = "timestamp,user_id,action,data,more_data,even_more_data,field1,field2,field3,field4,field5,field6,field7,field8,field9,field10"
             .repeat(50);
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         for i in 1..=5 {
             println!("=== Processing detailed message {i} ===");
@@ -1045,13 +1116,13 @@ mod tests {
             .collect();
 
         // Compress the data
-        let mut compressor = Compressor::new(Compression::default());
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
         let compressed = compressor
             .compress(&data, true)
             .expect("Compression failed");
 
         // Decompress the data
-        let mut decompressor = Decompressor::new();
+        let mut decompressor = Decompressor::new(HalfConfig::default());
         let decompressed = decompressor
             .decompress(&compressed, true)
             .expect("Decompression failed");
@@ -1106,8 +1177,8 @@ mod tests {
 
         let data = "long repeated string of CSV-like data".repeat(500); // Make it very long
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         // The issue mentions it happens after 2-5 messages, so let's test exactly that range
         for i in 1..=7 {
@@ -1162,8 +1233,8 @@ mod tests {
 
         let repetitive_data = "A".repeat(10000); // Very repetitive data
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         for i in 1..=8 {
             println!("Repetitive data test - message {i}");
@@ -1218,8 +1289,8 @@ mod tests {
                 .collect::<String>(),
         ];
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         for (pattern_idx, pattern) in patterns.iter().enumerate() {
             for msg_idx in 1..=5 {
@@ -1284,8 +1355,8 @@ mod tests {
             "This is a test message that will be fragmented across multiple frames. ".repeat(100);
         let chunk_size = 500; // Split into chunks of 500 bytes
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         let mut compressed_fragments = Vec::new();
         let mut offset = 0;
@@ -1356,8 +1427,8 @@ mod tests {
             "Third message continues the pattern: ".repeat(50),
         ];
 
-        let mut compressor = Compressor::new(Compression::default());
-        let mut decompressor = Decompressor::new();
+        let mut compressor = Compressor::new(Compression::default(), HalfConfig::default());
+        let mut decompressor = Decompressor::new(HalfConfig::default());
 
         for (msg_idx, message) in messages.iter().enumerate() {
             println!("Processing fragmented message {}", msg_idx + 1);
@@ -1422,7 +1493,8 @@ mod tests {
         let repetitive_message = "This is a repeated message. ".repeat(100);
 
         // Test with contextual compression (maintains state)
-        let mut contextual_compressor = Compressor::new(Compression::default());
+        let mut contextual_compressor =
+            Compressor::new(Compression::default(), HalfConfig::default());
         let mut compressed_sizes_contextual = Vec::new();
 
         for i in 0..5 {
@@ -1438,7 +1510,13 @@ mod tests {
         }
 
         // Test with no_context_takeover (resets state)
-        let mut no_context_compressor = Compressor::no_context_takeover(Compression::default());
+        let mut no_context_compressor = Compressor::new(
+            Compression::default(),
+            HalfConfig {
+                no_context_takeover: true,
+                window_bits: None,
+            },
+        );
         let mut compressed_sizes_no_context = Vec::new();
 
         for i in 0..5 {
@@ -1468,7 +1546,10 @@ mod tests {
         }
 
         // Test decompression works correctly with no_context_takeover
-        let mut no_context_decompressor = Decompressor::no_context_takeover();
+        let mut no_context_decompressor = Decompressor::new(HalfConfig {
+            no_context_takeover: true,
+            window_bits: None,
+        });
 
         for i in 0..5 {
             let compressed = no_context_compressor
@@ -1496,5 +1577,632 @@ mod tests {
             "Contextual compression sizes: {:?}",
             compressed_sizes_contextual
         );
+    }
+
+    /// A peer may finish its deflate stream with a final block (BFINAL=1) and append
+    /// trailing bytes the inflater can never consume. The inflate loop used to spin on
+    /// those bytes forever, pinning a core.
+    ///
+    /// See https://github.com/infinitefield/yawc/issues/40
+    #[test]
+    fn test_decompress_final_block_does_not_spin() {
+        let mut encoder = flate2::Compress::new(Compression::default(), false);
+        let data = b"the quick brown fox jumps over the lazy dog";
+
+        let mut compressed = vec![0u8; 256];
+        encoder
+            .compress(data, &mut compressed, flate2::FlushCompress::Finish)
+            .expect("compression failed");
+        compressed.truncate(encoder.total_out() as usize);
+        // Trailing bytes after the final block, as seen in the wild.
+        compressed.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+        let mut inflate = Inflate::default();
+        let decompressed = inflate
+            .decompress(&compressed, true)
+            .expect("decompression failed");
+        assert_eq!(decompressed.as_ref(), &data[..]);
+
+        // The context is reset, so the next message decompresses too.
+        let mut encoder = flate2::Compress::new(Compression::default(), false);
+        let mut compressed = vec![0u8; 256];
+        encoder
+            .compress(data, &mut compressed, flate2::FlushCompress::Finish)
+            .expect("compression failed");
+        compressed.truncate(encoder.total_out() as usize);
+
+        let decompressed = inflate
+            .decompress(&compressed, true)
+            .expect("decompression failed");
+        assert_eq!(decompressed.as_ref(), &data[..]);
+    }
+
+    /// The compressed payload from the issue report: an OCPP client whose deflate
+    /// stream ends with a final block plus four trailing bytes.
+    const ISSUE_40_PAYLOAD: &[u8] = &[
+        0x9d, 0x51, 0x3d, 0x6f, 0xc2, 0x30, 0x10, 0xfd, 0x2f, 0xb7, 0x36, 0x89, 0x9c, 0xef, 0x90,
+        0x0d, 0x2a, 0x86, 0x0c, 0x2d, 0x12, 0x44, 0xed, 0x80, 0x3a, 0xb8, 0xc9, 0x25, 0x44, 0x10,
+        0x9b, 0xda, 0x4e, 0x54, 0x8a, 0xf2, 0xdf, 0x7b, 0x86, 0x4a, 0x30, 0x74, 0x69, 0xe5, 0xe5,
+        0xfc, 0xfc, 0xee, 0xbd, 0x77, 0xe7, 0x6d, 0xe0, 0x40, 0x18, 0x87, 0x49, 0xd4, 0x04, 0x89,
+        0x5b, 0x21, 0xf7, 0xdd, 0x28, 0x41, 0xee, 0x72, 0xe4, 0xa9, 0x1b, 0xb1, 0xf7, 0x30, 0xce,
+        0x66, 0x59, 0xd2, 0x64, 0x08, 0x0e, 0x94, 0x8a, 0x0b, 0xcd, 0x2b, 0xd3, 0x49, 0xb1, 0x1c,
+        0x51, 0x18, 0x70, 0xce, 0x80, 0xb6, 0x28, 0x4f, 0x47, 0x84, 0x1c, 0x36, 0x86, 0x2b, 0x83,
+        0x35, 0x31, 0x71, 0xd4, 0x04, 0x9c, 0xa1, 0xab, 0x21, 0xf7, 0x1d, 0xa8, 0xa4, 0x10, 0x58,
+        0x19, 0xa9, 0x0a, 0x7b, 0x9f, 0x1c, 0x30, 0x5d, 0x8f, 0xda, 0xf0, 0xfe, 0x48, 0x5d, 0x01,
+        0x23, 0x63, 0x96, 0xba, 0x41, 0x56, 0xfa, 0x71, 0x1e, 0xcf, 0x72, 0x96, 0x78, 0x8c, 0xb1,
+        0x07, 0x96, 0xe5, 0x8c, 0x91, 0x96, 0x51, 0x5d, 0xdb, 0xa2, 0x5a, 0x23, 0xd7, 0x52, 0x10,
+        0x7f, 0x3e, 0x98, 0x9d, 0x54, 0xdd, 0xd7, 0xc5, 0x48, 0xe3, 0xc7, 0xb3, 0x24, 0xcd, 0x24,
+        0x9d, 0x39, 0xe4, 0x56, 0xca, 0x3d, 0x8a, 0xab, 0xf1, 0x4f, 0x09, 0x61, 0x18, 0x2e, 0x96,
+        0x91, 0x3f, 0xb7, 0x4a, 0xd7, 0x98, 0xc5, 0x66, 0xe5, 0x47, 0x51, 0x14, 0x82, 0x0d, 0x72,
+        0x1b, 0xa9, 0x10, 0x8d, 0xb4, 0xad, 0xf7, 0x10, 0xc5, 0x05, 0x3f, 0xb5, 0xc4, 0x1e, 0x0d,
+        0xaa, 0x17, 0x7e, 0x18, 0x48, 0x61, 0x7b, 0xfe, 0xd3, 0x00, 0x9a, 0x68, 0x07, 0xac, 0x6f,
+        0xcd, 0xe3, 0xb5, 0x62, 0x97, 0xc5, 0x18, 0xfc, 0x34, 0x24, 0x72, 0xb7, 0x5b, 0x6f, 0x81,
+        0x6d, 0x27, 0xc0, 0x7a, 0x72, 0x3d, 0x10, 0x6e, 0x53, 0x2c, 0x05, 0xaa, 0xf6, 0xe4, 0xcd,
+        0x89, 0x31, 0xa2, 0x57, 0xf4, 0x47, 0xa9, 0x8c, 0xb7, 0x26, 0xa2, 0xa6, 0x5c, 0xc4, 0x3d,
+        0xc8, 0x8a, 0xdb, 0x66, 0xa2, 0x2e, 0x64, 0x7d, 0x22, 0x64, 0x10, 0x9d, 0x59, 0x35, 0x4f,
+        0x17, 0x8d, 0xcb, 0x67, 0x58, 0x80, 0x9e, 0xf7, 0xaf, 0x3b, 0x98, 0x26, 0xe7, 0x7f, 0x31,
+        0x36, 0xf2, 0xf1, 0x17, 0xb3, 0xe9, 0xcd, 0x9e, 0x6f, 0x0b, 0x5b, 0xb9, 0x68,
+    ];
+
+    /// Exact payload from the issue report: an OCPP client whose deflate stream ends with
+    /// a final block plus four trailing bytes.
+    #[test]
+    fn test_decompress_issue_40_payload() {
+        let mut inflate = Inflate::default();
+        let decompressed = inflate
+            .decompress(ISSUE_40_PAYLOAD, true)
+            .expect("decompression failed");
+        assert!(decompressed
+            .starts_with(b"[2,\"35364f26-cea1-46ea-aea7-40b358986f8e\",\"TransactionEvent\""));
+        assert_eq!(decompressed.len(), 586);
+    }
+
+    /// The no-context-takeover path shares `Inflate::write`, so it must survive a final
+    /// block too. Its own reset is redundant here but harmless.
+    #[test]
+    fn test_decompress_no_context_final_block() {
+        let data = b"the quick brown fox jumps over the lazy dog";
+        let finished = |data: &[u8]| {
+            let mut encoder = flate2::Compress::new(Compression::default(), false);
+            let mut out = vec![0u8; 256];
+            encoder
+                .compress(data, &mut out, flate2::FlushCompress::Finish)
+                .expect("compression failed");
+            out.truncate(encoder.total_out() as usize);
+            out
+        };
+
+        let mut inflate = Inflate::default();
+        for _ in 0..3 {
+            let mut compressed = finished(data);
+            compressed.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+            let decompressed = inflate
+                .decompress(&compressed, true)
+                .expect("decompression failed");
+            assert_eq!(decompressed.as_ref(), &data[..]);
+            assert!(!inflate.stream_ended);
+        }
+    }
+
+    /// A final block arriving on a non-final fragment leaves the flag set until the
+    /// message completes, and must not spin on the remaining fragments either.
+    #[test]
+    fn test_decompress_final_block_mid_fragment() {
+        let data = b"the quick brown fox jumps over the lazy dog";
+        let mut encoder = flate2::Compress::new(Compression::default(), false);
+        let mut compressed = vec![0u8; 256];
+        encoder
+            .compress(data, &mut compressed, flate2::FlushCompress::Finish)
+            .expect("compression failed");
+        compressed.truncate(encoder.total_out() as usize);
+
+        let mut inflate = Inflate::default();
+        let first = inflate
+            .decompress(&compressed, false)
+            .expect("decompression failed");
+        assert!(inflate.stream_ended);
+
+        let last = inflate
+            .decompress(&[0xde, 0xad], true)
+            .expect("decompression failed");
+        assert_eq!([first, last].concat(), &data[..]);
+        assert!(!inflate.stream_ended);
+    }
+
+    /// Round trip at every negotiable window size. The existing window-bits tests only
+    /// checked buffer capacity, so no data ever went through a non-default window.
+    #[cfg(feature = "zlib")]
+    #[test]
+    fn test_window_bits_round_trip() {
+        let messages: [&[u8]; 4] = [
+            b"short",
+            b"the quick brown fox jumps over the lazy dog",
+            &[b'a'; 4096],
+            b"{\"eventType\":\"Started\",\"evse\":{\"id\":1,\"connectorId\":1}}",
+        ];
+
+        for bits in 9..=15u8 {
+            let mut deflate = Deflate::new_with_window_bits(Compression::default(), bits);
+            let mut inflate = Inflate::new_with_window_bits(bits);
+
+            for message in messages {
+                let compressed = deflate.compress(message, true).expect("compression failed");
+                let decompressed = inflate
+                    .decompress(&compressed, true)
+                    .expect("decompression failed");
+                assert_eq!(
+                    decompressed.as_ref(),
+                    message,
+                    "round trip failed at {bits} window bits"
+                );
+            }
+        }
+    }
+
+    /// Same, with the context reset between messages.
+    #[cfg(feature = "zlib")]
+    #[test]
+    fn test_window_bits_round_trip_no_context() {
+        for bits in 9..=15u8 {
+            let mut deflate = Deflate::new_with_window_bits(Compression::default(), bits);
+            let mut inflate = Inflate::new_with_window_bits(bits);
+
+            for i in 0..4 {
+                let message = format!("message number {i} with some repeated repeated text");
+                let compressed = deflate
+                    .compress(message.as_bytes(), true)
+                    .expect("compression failed");
+                deflate.reset();
+                let decompressed = inflate
+                    .decompress(&compressed, true)
+                    .expect("decompression failed");
+                inflate.reset();
+                assert_eq!(
+                    decompressed.as_ref(),
+                    message.as_bytes(),
+                    "round trip failed at {bits} window bits"
+                );
+            }
+        }
+    }
+
+    /// The reporter negotiated `client_max_window_bits=10`, so the inbound inflater used a
+    /// 10-bit window. Decode their payload through that exact configuration.
+    #[cfg(feature = "zlib")]
+    #[test]
+    fn test_decompress_issue_40_payload_window_bits_10() {
+        let mut inflate = Inflate::new_with_window_bits(10);
+        let decompressed = inflate
+            .decompress(ISSUE_40_PAYLOAD, true)
+            .expect("decompression failed");
+        assert_eq!(decompressed.len(), 586);
+    }
+
+    /// A final block must not spin the inflate loop at a non-default window size either.
+    #[cfg(feature = "zlib")]
+    #[test]
+    fn test_window_bits_final_block_does_not_spin() {
+        for bits in 9..=15u8 {
+            let mut encoder =
+                flate2::Compress::new_with_window_bits(Compression::default(), false, bits);
+            let data = b"the quick brown fox jumps over the lazy dog";
+
+            let mut compressed = vec![0u8; 256];
+            encoder
+                .compress(data, &mut compressed, flate2::FlushCompress::Finish)
+                .expect("compression failed");
+            compressed.truncate(encoder.total_out() as usize);
+            compressed.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+
+            let mut inflate = Inflate::new_with_window_bits(bits);
+            let decompressed = inflate
+                .decompress(&compressed, true)
+                .expect("decompression failed");
+            assert_eq!(decompressed.as_ref(), &data[..]);
+            assert!(!inflate.stream_ended);
+        }
+    }
+
+    // ============================ Fuzzing ============================
+    //
+    // These run in the normal test suite with a fixed seed so failures reproduce.
+    // The coverage-guided fuzz targets live in `fuzz/` and are run separately with
+    // `cargo make fuzz` (see fuzz/README.md).
+
+    /// Small xorshift PRNG. A seeded generator keeps these tests deterministic and
+    /// avoids a dev-dependency just to produce bytes.
+    struct Rng(u64);
+
+    impl Rng {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+            self.0 = x;
+            x
+        }
+
+        /// Uniform enough for generating test inputs.
+        fn below(&mut self, n: usize) -> usize {
+            (self.next_u64() % n as u64) as usize
+        }
+
+        fn bytes(&mut self, len: usize) -> Vec<u8> {
+            (0..len).map(|_| self.next_u64() as u8).collect()
+        }
+
+        /// Payloads that stress the inflater differently: incompressible noise,
+        /// highly repetitive runs, and text-like data.
+        fn payload(&mut self, len: usize) -> Vec<u8> {
+            match self.below(3) {
+                0 => self.bytes(len),
+                1 => {
+                    let byte = self.next_u64() as u8;
+                    vec![byte; len]
+                }
+                _ => {
+                    let words = ["ok", "event", "id", "timestamp", "value", "{}", "\"a\""];
+                    let mut out = Vec::with_capacity(len);
+                    while out.len() < len {
+                        out.extend_from_slice(words[self.below(words.len())].as_bytes());
+                    }
+                    out.truncate(len);
+                    out
+                }
+            }
+        }
+    }
+
+    /// Runs `case` for each iteration on a detached thread, failing if any single case
+    /// stops making progress. A spinning inflate loop never yields, so it cannot be
+    /// caught by an assertion inside the case itself.
+    ///
+    /// The last-started iteration is published so a failure names the exact case, which
+    /// together with the fixed seed makes it reproducible.
+    fn run_with_watchdog(
+        name: &str,
+        seed: u64,
+        iterations: usize,
+        case: impl Fn(&mut Rng, usize) + Send + 'static,
+    ) {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::{mpsc, Arc};
+        use std::time::Duration;
+
+        let progress = Arc::new(AtomicUsize::new(0));
+        let reported = Arc::clone(&progress);
+        let (tx, rx) = mpsc::channel();
+
+        std::thread::spawn(move || {
+            let mut rng = Rng(seed);
+            for i in 0..iterations {
+                reported.store(i, Ordering::Relaxed);
+                case(&mut rng, i);
+            }
+            let _ = tx.send(());
+        });
+
+        // The whole batch runs in a few seconds, so this only trips on a real hang.
+        if rx.recv_timeout(Duration::from_secs(30)).is_err() {
+            panic!(
+                "{name}: iteration {} did not terminate (seed {seed}). \
+                 Rerun with this seed to reproduce.",
+                progress.load(Ordering::Relaxed)
+            );
+        }
+    }
+
+    /// Arbitrary bytes must never hang or panic the inflater: it either decompresses
+    /// them or returns an error. This is the shape of the issue #40 bug, where a
+    /// well-formed stream with unconsumable trailing bytes spun forever.
+    #[test]
+    fn test_fuzz_decompress_arbitrary_input() {
+        run_with_watchdog(
+            "decompress_arbitrary_input",
+            0x5eed_1234,
+            20_000,
+            |rng, _| {
+                let len = rng.below(512);
+                let input = rng.bytes(len);
+
+                let mut inflate = if rng.below(2) == 0 {
+                    Inflate::default()
+                } else {
+                    #[cfg(feature = "zlib")]
+                    {
+                        Inflate::new_with_window_bits(9 + rng.below(7) as u8)
+                    }
+                    #[cfg(not(feature = "zlib"))]
+                    {
+                        Inflate::default()
+                    }
+                };
+
+                let stream_end = rng.below(2) == 0;
+                // Result is irrelevant, termination without panicking is the property.
+                let _ = inflate.decompress(&input, stream_end);
+            },
+        );
+    }
+
+    /// Same, but starting from a well-formed deflate stream that is then corrupted,
+    /// truncated, or extended. Random bytes rarely form a valid stream header, so this
+    /// reaches decoder states the fully random test does not.
+    #[test]
+    fn test_fuzz_decompress_mutated_stream() {
+        run_with_watchdog(
+            "decompress_mutated_stream",
+            0x5eed_abcd,
+            20_000,
+            |rng, _| {
+                let len = 1 + rng.below(400);
+                let data = rng.payload(len);
+
+                let mut encoder = flate2::Compress::new(Compression::default(), false);
+                let mut stream = vec![0u8; 2048];
+                let flush = match rng.below(4) {
+                    0 => flate2::FlushCompress::Sync,
+                    1 => flate2::FlushCompress::Partial,
+                    2 => flate2::FlushCompress::Full,
+                    _ => flate2::FlushCompress::Finish,
+                };
+                if encoder.compress(&data, &mut stream, flush).is_err() {
+                    return;
+                }
+                stream.truncate(encoder.total_out() as usize);
+
+                match rng.below(4) {
+                    // Flip a bit.
+                    0 if !stream.is_empty() => {
+                        let at = rng.below(stream.len());
+                        stream[at] ^= 1 << rng.below(8);
+                    }
+                    // Truncate.
+                    1 if !stream.is_empty() => {
+                        let keep = rng.below(stream.len());
+                        stream.truncate(keep);
+                    }
+                    // Append trailing bytes, the issue #40 shape.
+                    2 => {
+                        let extra_len = rng.below(8);
+                        let extra = rng.bytes(extra_len);
+                        stream.extend_from_slice(&extra);
+                    }
+                    _ => {}
+                }
+
+                let mut inflate = Inflate::default();
+
+                // Deliver as one or more fragments, ending the message on the last.
+                let fragments = 1 + rng.below(3);
+                let mut offset = 0;
+                for fragment in 0..fragments {
+                    let last = fragment + 1 == fragments;
+                    let end = if last {
+                        stream.len()
+                    } else {
+                        offset + rng.below(stream.len() - offset + 1)
+                    };
+                    if inflate.decompress(&stream[offset..end], last).is_err() {
+                        break;
+                    }
+                    offset = end;
+                }
+            },
+        );
+    }
+
+    /// Round trip: whatever the compressor produces, the decompressor must reproduce
+    /// exactly. Exercises both loops, including the compressor's flush loop.
+    #[test]
+    fn test_fuzz_round_trip() {
+        run_with_watchdog("round_trip", 0x5eed_beef, 5_000, |rng, i| {
+            let level = Compression::new(rng.below(10) as u32);
+            let no_context = rng.below(2) == 0;
+
+            let (mut deflate, mut inflate) = match rng.below(2) {
+                #[cfg(feature = "zlib")]
+                0 => {
+                    let bits = 9 + rng.below(7) as u8;
+                    (
+                        Deflate::new_with_window_bits(level, bits),
+                        Inflate::new_with_window_bits(bits),
+                    )
+                }
+                _ => (Deflate::new(level), Inflate::default()),
+            };
+
+            // Several messages over one connection, so context takeover is exercised.
+            for _ in 0..1 + rng.below(4) {
+                let len = rng.below(2048);
+                let data = rng.payload(len);
+
+                let (compressed, decompressed) = if no_context {
+                    let compressed = deflate.compress(&data, true).expect("compression failed");
+                    deflate.reset();
+                    let decompressed = inflate
+                        .decompress(&compressed, true)
+                        .expect("decompression failed");
+                    inflate.reset();
+                    (compressed, decompressed)
+                } else {
+                    let compressed = deflate.compress(&data, true).expect("compression failed");
+                    let decompressed = inflate
+                        .decompress(&compressed, true)
+                        .expect("decompression failed");
+                    (compressed, decompressed)
+                };
+
+                assert_eq!(
+                    decompressed.as_ref(),
+                    &data[..],
+                    "round trip mismatch on iteration {i} ({} bytes in, {} compressed)",
+                    data.len(),
+                    compressed.len()
+                );
+            }
+        });
+    }
+
+    /// Minimised by the `websocket_read` fuzz target from the issue #40 hang: a two-byte
+    /// deflate payload holding nothing but an empty final block. Reaching the end of the
+    /// stream with a single byte still pending was enough to spin the inflate loop.
+    #[test]
+    fn test_decompress_minimal_final_block() {
+        let mut inflate = Inflate::default();
+        let decompressed = inflate
+            .decompress(&[0x03, 0x80], true)
+            .expect("decompression failed");
+        assert!(decompressed.is_empty());
+        assert!(!inflate.stream_ended);
+    }
+
+    #[test]
+    fn test_looks_incompressible_detects_random_data() {
+        let mut rng = Rng(0x9e37_79b9);
+        for _ in 0..64 {
+            let data = rng.bytes(4096);
+            assert!(
+                looks_incompressible(&data),
+                "random bytes should read as already compressed"
+            );
+        }
+    }
+
+    #[test]
+    fn test_looks_incompressible_detects_deflated_data() {
+        let mut rng = Rng(0x1111);
+        for _ in 0..32 {
+            let len = 4096 + rng.below(4096);
+            let text: Vec<u8> = (0..len).map(|i| b"abcdefghij "[i % 11]).collect();
+
+            let mut deflate = Deflate::new(Compression::best());
+            let compressed = deflate.compress(&text, true).expect("compression failed");
+
+            // Only meaningful once the output is long enough to sample.
+            if compressed.len() >= INCOMPRESSIBLE_MIN_LEN {
+                assert!(
+                    looks_incompressible(&compressed),
+                    "deflate output should read as already compressed"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_looks_incompressible_passes_real_payloads() {
+        let json: Vec<u8> = (0..200)
+            .flat_map(|i| {
+                format!(r#"{{"id":{i},"event":"TransactionEvent","ok":true,"seq":{i}}},"#)
+                    .into_bytes()
+            })
+            .collect();
+        assert!(!looks_incompressible(&json), "json should be compressed");
+
+        let text = "the quick brown fox jumps over the lazy dog. "
+            .repeat(200)
+            .into_bytes();
+        assert!(!looks_incompressible(&text), "text should be compressed");
+
+        let zeros = vec![0u8; 8192];
+        assert!(!looks_incompressible(&zeros), "zeros should be compressed");
+
+        // A compressed blob behind a low-entropy header: sampling the prefix alone
+        // would misread this as compressible.
+        let mut rng = Rng(0x2222);
+        let mut framed = vec![0u8; 512];
+        framed.extend_from_slice(&rng.bytes(8192));
+        assert!(
+            looks_incompressible(&framed),
+            "a low-entropy header should not hide the body"
+        );
+    }
+
+    /// The role decides which negotiated half applies to which direction. Getting this
+    /// backwards would still round trip against yawc itself, so it is pinned here.
+    #[test]
+    fn test_compression_config_maps_role_to_direction() {
+        let extensions = WebSocketExtensions {
+            server_max_window_bits: Some(Some(11)),
+            client_max_window_bits: Some(Some(13)),
+            server_no_context_takeover: true,
+            client_no_context_takeover: false,
+        };
+        let level = Some(CompressionLevel::default());
+
+        let client = CompressionConfig::resolve(Some(&extensions), level, false, Role::Client)
+            .expect("resolve")
+            .expect("negotiated");
+        let server = CompressionConfig::resolve(Some(&extensions), level, false, Role::Server)
+            .expect("resolve")
+            .expect("negotiated");
+
+        // A client writes with the client_* half and reads the server_* half.
+        assert!(!client.outgoing.no_context_takeover);
+        assert!(client.incoming.no_context_takeover);
+        assert_eq!(client.outgoing.window_bits, Some(13));
+        assert_eq!(client.incoming.window_bits, Some(11));
+
+        // A server is the mirror image.
+        assert_eq!(server.outgoing, client.incoming);
+        assert_eq!(server.incoming, client.outgoing);
+    }
+
+    /// Window bits are clamped for every direction and role. Only one of the four
+    /// original code paths did this, so a peer could push an unsupported size through
+    /// the other three.
+    #[test]
+    fn test_compression_config_clamps_window_bits() {
+        for bits in [0u8, 1, 7, 8, 16, 255] {
+            let extensions = WebSocketExtensions {
+                server_max_window_bits: Some(Some(bits)),
+                client_max_window_bits: Some(Some(bits)),
+                ..Default::default()
+            };
+
+            for role in [Role::Client, Role::Server] {
+                let config = CompressionConfig::resolve(
+                    Some(&extensions),
+                    Some(CompressionLevel::default()),
+                    false,
+                    role,
+                )
+                .expect("resolve")
+                .expect("negotiated");
+
+                for half in [config.outgoing, config.incoming] {
+                    let window_bits = half.window_bits.expect("window bits");
+                    assert!(
+                        WINDOW_BITS.contains(&window_bits),
+                        "{bits} was not clamped for {role}, got {window_bits}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// A peer must not be able to turn compression on unilaterally. RFC 6455,
+    /// Section 4.1 requires a client to fail when the response names an extension it
+    /// never offered; this used to panic on an unwrap instead.
+    #[test]
+    fn test_compression_config_rejects_unoffered_extension() {
+        let err = CompressionConfig::resolve(
+            Some(&WebSocketExtensions::default()),
+            None,
+            false,
+            Role::Client,
+        )
+        .expect_err("an unoffered extension must be rejected");
+
+        assert!(matches!(err, WebSocketError::CompressionNotSupported));
+    }
+
+    /// No extension negotiated means no compression, not an error.
+    #[test]
+    fn test_compression_config_absent_without_extension() {
+        let config = CompressionConfig::resolve(None, None, false, Role::Client).expect("resolve");
+        assert!(config.is_none());
     }
 }

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -237,8 +237,6 @@ pub(crate) struct CompressionConfig {
     outgoing: HalfConfig,
     /// Settings for the direction we decompress.
     incoming: HalfConfig,
-    /// Send already-compressed payloads without deflating them again.
-    pub(crate) skip_incompressible: bool,
 }
 
 impl CompressionConfig {
@@ -255,7 +253,6 @@ impl CompressionConfig {
     pub(crate) fn resolve(
         extensions: Option<&WebSocketExtensions>,
         level: Option<CompressionLevel>,
-        skip_incompressible: bool,
         role: Role,
     ) -> crate::Result<Option<Self>> {
         let Some(extensions) = extensions else {
@@ -290,7 +287,6 @@ impl CompressionConfig {
             level,
             outgoing,
             incoming,
-            skip_incompressible,
         }))
     }
 
@@ -459,58 +455,6 @@ fn inflate_error(err: DecompressError) -> io::Error {
         io::ErrorKind::InvalidInput,
         format!("Decompression error: {err}"),
     )
-}
-
-/// Payloads below this size are always compressed: the sampling is not reliable on a
-/// short payload, and the work saved would be negligible anyway.
-pub(crate) const INCOMPRESSIBLE_MIN_LEN: usize = 1024;
-
-/// Number of bytes sampled when estimating whether a payload is already compressed.
-const ENTROPY_SAMPLE: usize = 2048;
-
-/// Shannon entropy above which a payload is treated as already compressed.
-///
-/// Compressed and encrypted data sits at ~7.9-8.0 bits per byte; text, JSON and most
-/// binary formats sit well below 7. The gap is wide, so the exact cutoff is not
-/// delicate.
-const INCOMPRESSIBLE_ENTROPY: f32 = 7.5;
-
-/// Estimates whether `data` is already compressed, and so not worth deflating.
-///
-/// Deflating already-compressed input is the most expensive case there is and makes the
-/// payload larger, so it is worth a cheap check first. This samples evenly across the
-/// payload rather than reading a prefix, since compressed formats often start with a
-/// low-entropy header.
-///
-/// Being wrong is not a correctness problem in either direction: a false positive sends
-/// a compressible message uncompressed, a false negative wastes the work it would have
-/// spent anyway.
-pub(crate) fn looks_incompressible(data: &[u8]) -> bool {
-    let mut histogram = [0u32; 256];
-    let mut sampled = 0u32;
-
-    // Stride so the sample spans the whole payload.
-    let stride = (data.len() / ENTROPY_SAMPLE).max(1);
-    for byte in data.iter().step_by(stride).take(ENTROPY_SAMPLE) {
-        histogram[*byte as usize] += 1;
-        sampled += 1;
-    }
-
-    if sampled == 0 {
-        return false;
-    }
-
-    let total = sampled as f32;
-    let entropy: f32 = histogram
-        .iter()
-        .filter(|count| **count > 0)
-        .map(|count| {
-            let p = *count as f32 / total;
-            -p * p.log2()
-        })
-        .sum();
-
-    entropy >= INCOMPRESSIBLE_ENTROPY
 }
 
 /// Returns a mutable slice to the next available chunk of memory in the BytesMut buffer.
@@ -735,8 +679,7 @@ mod tests {
     use flate2::Compression;
 
     use crate::compression::{
-        looks_incompressible, CompressionConfig, Compressor, Decompressor, Deflate, HalfConfig,
-        Inflate, INCOMPRESSIBLE_MIN_LEN, WINDOW_BITS,
+        CompressionConfig, Compressor, Decompressor, Deflate, HalfConfig, Inflate, WINDOW_BITS,
     };
     use crate::{CompressionLevel, Role, WebSocketError};
 
@@ -2059,67 +2002,6 @@ mod tests {
         assert!(!inflate.stream_ended);
     }
 
-    #[test]
-    fn test_looks_incompressible_detects_random_data() {
-        let mut rng = Rng(0x9e37_79b9);
-        for _ in 0..64 {
-            let data = rng.bytes(4096);
-            assert!(
-                looks_incompressible(&data),
-                "random bytes should read as already compressed"
-            );
-        }
-    }
-
-    #[test]
-    fn test_looks_incompressible_detects_deflated_data() {
-        let mut rng = Rng(0x1111);
-        for _ in 0..32 {
-            let len = 4096 + rng.below(4096);
-            let text: Vec<u8> = (0..len).map(|i| b"abcdefghij "[i % 11]).collect();
-
-            let mut deflate = Deflate::new(Compression::best());
-            let compressed = deflate.compress(&text, true).expect("compression failed");
-
-            // Only meaningful once the output is long enough to sample.
-            if compressed.len() >= INCOMPRESSIBLE_MIN_LEN {
-                assert!(
-                    looks_incompressible(&compressed),
-                    "deflate output should read as already compressed"
-                );
-            }
-        }
-    }
-
-    #[test]
-    fn test_looks_incompressible_passes_real_payloads() {
-        let json: Vec<u8> = (0..200)
-            .flat_map(|i| {
-                format!(r#"{{"id":{i},"event":"TransactionEvent","ok":true,"seq":{i}}},"#)
-                    .into_bytes()
-            })
-            .collect();
-        assert!(!looks_incompressible(&json), "json should be compressed");
-
-        let text = "the quick brown fox jumps over the lazy dog. "
-            .repeat(200)
-            .into_bytes();
-        assert!(!looks_incompressible(&text), "text should be compressed");
-
-        let zeros = vec![0u8; 8192];
-        assert!(!looks_incompressible(&zeros), "zeros should be compressed");
-
-        // A compressed blob behind a low-entropy header: sampling the prefix alone
-        // would misread this as compressible.
-        let mut rng = Rng(0x2222);
-        let mut framed = vec![0u8; 512];
-        framed.extend_from_slice(&rng.bytes(8192));
-        assert!(
-            looks_incompressible(&framed),
-            "a low-entropy header should not hide the body"
-        );
-    }
-
     /// The role decides which negotiated half applies to which direction. Getting this
     /// backwards would still round trip against yawc itself, so it is pinned here.
     #[test]
@@ -2132,10 +2014,10 @@ mod tests {
         };
         let level = Some(CompressionLevel::default());
 
-        let client = CompressionConfig::resolve(Some(&extensions), level, false, Role::Client)
+        let client = CompressionConfig::resolve(Some(&extensions), level, Role::Client)
             .expect("resolve")
             .expect("negotiated");
-        let server = CompressionConfig::resolve(Some(&extensions), level, false, Role::Server)
+        let server = CompressionConfig::resolve(Some(&extensions), level, Role::Server)
             .expect("resolve")
             .expect("negotiated");
 
@@ -2166,7 +2048,6 @@ mod tests {
                 let config = CompressionConfig::resolve(
                     Some(&extensions),
                     Some(CompressionLevel::default()),
-                    false,
                     role,
                 )
                 .expect("resolve")
@@ -2188,13 +2069,9 @@ mod tests {
     /// never offered; this used to panic on an unwrap instead.
     #[test]
     fn test_compression_config_rejects_unoffered_extension() {
-        let err = CompressionConfig::resolve(
-            Some(&WebSocketExtensions::default()),
-            None,
-            false,
-            Role::Client,
-        )
-        .expect_err("an unoffered extension must be rejected");
+        let err =
+            CompressionConfig::resolve(Some(&WebSocketExtensions::default()), None, Role::Client)
+                .expect_err("an unoffered extension must be rejected");
 
         assert!(matches!(err, WebSocketError::CompressionNotSupported));
     }
@@ -2202,7 +2079,7 @@ mod tests {
     /// No extension negotiated means no compression, not an error.
     #[test]
     fn test_compression_config_absent_without_extension() {
-        let config = CompressionConfig::resolve(None, None, false, Role::Client).expect("resolve");
+        let config = CompressionConfig::resolve(None, None, Role::Client).expect("resolve");
         assert!(config.is_none());
     }
 }

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -237,10 +237,6 @@ impl Negotiation {
         let compression = CompressionConfig::resolve(
             extensions.as_ref(),
             options.compression.as_ref().map(|deflate| deflate.level),
-            options
-                .compression
-                .as_ref()
-                .is_some_and(|deflate| deflate.skip_incompressible),
             role,
         )?;
 
@@ -271,11 +267,6 @@ impl Negotiation {
         self.compression
             .as_ref()
             .map(CompressionConfig::decompressor)
-    }
-
-    pub(crate) fn skip_incompressible(&self) -> bool {
-        self.compression
-            .is_some_and(|compression| compression.skip_incompressible)
     }
 }
 
@@ -2303,65 +2294,6 @@ mod tests {
 
             assert_eq!(opcode, OpCode::Text);
             assert_eq!(payload, TEXT.as_bytes());
-        }
-    }
-
-    /// Deflating already-compressed data costs the most CPU of any input and makes the
-    /// frame larger, so `skip_incompressible` sends it as-is. The peer must still
-    /// receive it intact, and compressible traffic must be unaffected.
-    #[tokio::test]
-    async fn test_skip_incompressible_round_trip() {
-        fn negotiation(skip_incompressible: bool, role: Role) -> Negotiation {
-            let mut options =
-                Options::default().with_compression_level(CompressionLevel::default());
-            if skip_incompressible {
-                options = options.skip_incompressible();
-            }
-            Negotiation::new(Some(WebSocketExtensions::default()), &options, role)
-                .expect("negotiation")
-        }
-
-        // Deterministic high-entropy payload, as an already-compressed body would be.
-        let mut state = 0x2545_f491_4f6c_dd1du64;
-        let incompressible: Vec<u8> = (0..8192)
-            .map(|_| {
-                state ^= state << 13;
-                state ^= state >> 7;
-                state ^= state << 17;
-                state as u8
-            })
-            .collect();
-        let compressible = b"the quick brown fox jumps over the lazy dog. ".repeat(200);
-
-        for skip in [false, true] {
-            let (client_stream, server_stream) = MockStream::pair(1 << 16);
-            let mut client = WebSocket::new(
-                Role::Client,
-                client_stream,
-                Bytes::new(),
-                negotiation(skip, Role::Client),
-            );
-            let mut server = WebSocket::new(
-                Role::Server,
-                server_stream,
-                Bytes::new(),
-                negotiation(skip, Role::Server),
-            );
-
-            for payload in [incompressible.clone(), compressible.clone()] {
-                client
-                    .send(Frame::binary(payload.clone()))
-                    .await
-                    .expect("send failed");
-
-                let frame = server.next_frame().await.expect("receive failed");
-                assert_eq!(frame.opcode(), OpCode::Binary);
-                assert_eq!(
-                    frame.payload(),
-                    &payload[..],
-                    "payload corrupted with skip_incompressible={skip}"
-                );
-            }
         }
     }
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -145,7 +145,7 @@ use std::{
 use tokio::io::{AsyncRead, AsyncWrite};
 
 use codec::Codec;
-use compression::{Compressor, Decompressor, WebSocketExtensions};
+use compression::{CompressionConfig, Compressor, Decompressor, WebSocketExtensions};
 use futures::{task::AtomicWaker, SinkExt};
 use tokio_rustls::rustls::{self, pki_types::TrustAnchor};
 use tokio_util::codec::Framed;
@@ -210,8 +210,7 @@ pub type UpgradeResult = Result<(HttpResponse, UpgradeFut)>;
 /// Parameters negotiated with the client or the server.
 #[derive(Debug, Default, Clone)]
 pub(crate) struct Negotiation {
-    pub(crate) extensions: Option<WebSocketExtensions>,
-    pub(crate) compression_level: Option<CompressionLevel>,
+    pub(crate) compression: Option<CompressionConfig>,
     pub(crate) max_payload_read: usize,
     pub(crate) max_read_buffer: usize,
     pub(crate) utf8: bool,
@@ -220,94 +219,63 @@ pub(crate) struct Negotiation {
 }
 
 impl Negotiation {
-    pub(crate) fn decompressor(&self, role: Role) -> Option<Decompressor> {
-        let config = self.extensions.as_ref()?;
+    /// Resolves the negotiated extensions and the local options into the settings a
+    /// connection runs with.
+    ///
+    /// Every handshake path goes through here, so the mapping from [`Options`] lives in
+    /// one place.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the peer negotiated permessage-deflate but this side never
+    /// offered it. See [`CompressionConfig::resolve`].
+    pub(crate) fn new(
+        extensions: Option<WebSocketExtensions>,
+        options: &Options,
+        role: Role,
+    ) -> Result<Self> {
+        let compression = CompressionConfig::resolve(
+            extensions.as_ref(),
+            options.compression.as_ref().map(|deflate| deflate.level),
+            options
+                .compression
+                .as_ref()
+                .is_some_and(|deflate| deflate.skip_incompressible),
+            role,
+        )?;
 
-        log::debug!(
-            "Established decompressor for {role} with settings \
-            client_no_context_takeover={} server_no_context_takeover={} \
-            server_max_window_bits={:?} client_max_window_bits={:?}",
-            config.client_no_context_takeover,
-            config.server_no_context_takeover,
-            config.server_max_window_bits,
-            config.client_max_window_bits
+        // The read buffer holds at least two payloads unless told otherwise.
+        let max_payload_read = options.max_payload_read.unwrap_or(MAX_PAYLOAD_READ);
+        let max_read_buffer = options.max_read_buffer.unwrap_or(
+            options
+                .max_payload_read
+                .map(|payload_read| payload_read * 2)
+                .unwrap_or(MAX_READ_BUFFER),
         );
 
-        // configure the decompressor using the assigned role and preferred flags.
-        Some(if role == Role::Server {
-            if config.client_no_context_takeover {
-                Decompressor::no_context_takeover()
-            } else {
-                #[cfg(feature = "zlib")]
-                if let Some(Some(window_bits)) = config.client_max_window_bits {
-                    Decompressor::new_with_window_bits(window_bits.max(9))
-                } else {
-                    Decompressor::new()
-                }
-                #[cfg(not(feature = "zlib"))]
-                Decompressor::new()
-            }
-        } else {
-            // client
-            if config.server_no_context_takeover {
-                Decompressor::no_context_takeover()
-            } else {
-                #[cfg(feature = "zlib")]
-                if let Some(Some(window_bits)) = config.server_max_window_bits {
-                    Decompressor::new_with_window_bits(window_bits)
-                } else {
-                    Decompressor::new()
-                }
-                #[cfg(not(feature = "zlib"))]
-                Decompressor::new()
-            }
+        Ok(Self {
+            compression,
+            max_payload_read,
+            max_read_buffer,
+            utf8: options.check_utf8,
+            fragmentation: options.fragmentation.clone(),
+            max_backpressure_write_boundary: options.max_backpressure_write_boundary,
         })
     }
 
-    pub(crate) fn compressor(&self, role: Role) -> Option<Compressor> {
-        let config = self.extensions.as_ref()?;
+    pub(crate) fn compressor(&self) -> Option<Compressor> {
+        self.compression.as_ref().map(CompressionConfig::compressor)
+    }
 
-        log::debug!(
-            "Established compressor for {role} with settings \
-            client_no_context_takeover={} server_no_context_takeover={} \
-            server_max_window_bits={:?} client_max_window_bits={:?}",
-            config.client_no_context_takeover,
-            config.server_no_context_takeover,
-            config.server_max_window_bits,
-            config.client_max_window_bits
-        );
+    pub(crate) fn decompressor(&self) -> Option<Decompressor> {
+        self.compression
+            .as_ref()
+            .map(CompressionConfig::decompressor)
+    }
 
-        let level = self.compression_level.unwrap();
-
-        // configure the compressor using the assigned role and preferred flags.
-        Some(if role == Role::Client {
-            if config.client_no_context_takeover {
-                Compressor::no_context_takeover(level)
-            } else {
-                #[cfg(feature = "zlib")]
-                if let Some(Some(window_bits)) = config.client_max_window_bits {
-                    Compressor::new_with_window_bits(level, window_bits)
-                } else {
-                    Compressor::new(level)
-                }
-                #[cfg(not(feature = "zlib"))]
-                Compressor::new(level)
-            }
-        } else {
-            // server
-            if config.server_no_context_takeover {
-                Compressor::no_context_takeover(level)
-            } else {
-                #[cfg(feature = "zlib")]
-                if let Some(Some(window_bits)) = config.server_max_window_bits {
-                    Compressor::new_with_window_bits(level, window_bits)
-                } else {
-                    Compressor::new(level)
-                }
-                #[cfg(not(feature = "zlib"))]
-                Compressor::new(level)
-            }
-        })
+    pub(crate) fn skip_incompressible(&self) -> bool {
+        self.compression
+            .is_some_and(|compression| compression.skip_incompressible)
     }
 }
 
@@ -1100,27 +1068,9 @@ impl WebSocket<HttpStream> {
             None
         };
 
-        let max_read_buffer = options.max_read_buffer.unwrap_or(
-            options
-                .max_payload_read
-                .map(|payload_read| payload_read * 2)
-                .unwrap_or(MAX_READ_BUFFER),
-        );
-
         let stream = UpgradeFut {
             inner: hyper::upgrade::on(request),
-            negotiation: Some(Negotiation {
-                extensions,
-                compression_level: options
-                    .compression
-                    .as_ref()
-                    .map(|compression| compression.level),
-                max_payload_read: options.max_payload_read.unwrap_or(MAX_PAYLOAD_READ),
-                max_read_buffer,
-                utf8: options.check_utf8,
-                fragmentation: options.fragmentation.clone(),
-                max_backpressure_write_boundary: options.max_backpressure_write_boundary,
-            }),
+            negotiation: Some(Negotiation::new(extensions, &options, Role::Server)?),
         };
 
         Ok((response, stream))
@@ -1303,7 +1253,6 @@ fn verify_reqwest(response: &reqwest::Response, options: Options) -> Result<Nego
         ));
     }
 
-    let compression_level = options.compression.as_ref().map(|opts| opts.level);
     let headers = response.headers();
 
     if !headers
@@ -1330,22 +1279,7 @@ fn verify_reqwest(response: &reqwest::Response, options: Options) -> Result<Nego
         .map(WebSocketExtensions::from_str)
         .and_then(std::result::Result::ok);
 
-    let max_read_buffer = options.max_read_buffer.unwrap_or(
-        options
-            .max_payload_read
-            .map(|payload_read| payload_read * 2)
-            .unwrap_or(MAX_READ_BUFFER),
-    );
-
-    Ok(Negotiation {
-        extensions,
-        compression_level,
-        max_payload_read: options.max_payload_read.unwrap_or(MAX_PAYLOAD_READ),
-        max_read_buffer,
-        utf8: options.check_utf8,
-        fragmentation: options.fragmentation.clone(),
-        max_backpressure_write_boundary: options.max_backpressure_write_boundary,
-    })
+    Negotiation::new(extensions, &options, Role::Client)
 }
 
 fn verify(response: &Response<Incoming>, options: Options) -> Result<Negotiation> {
@@ -1369,7 +1303,6 @@ fn verify(response: &Response<Incoming>, options: Options) -> Result<Negotiation
         ));
     }
 
-    let compression_level = options.compression.as_ref().map(|opts| opts.level);
     let headers = response.headers();
 
     if !headers
@@ -1396,22 +1329,7 @@ fn verify(response: &Response<Incoming>, options: Options) -> Result<Negotiation
         .map(WebSocketExtensions::from_str)
         .and_then(std::result::Result::ok);
 
-    let max_read_buffer = options.max_read_buffer.unwrap_or(
-        options
-            .max_payload_read
-            .map(|payload_read| payload_read * 2)
-            .unwrap_or(MAX_READ_BUFFER),
-    );
-
-    Ok(Negotiation {
-        extensions,
-        compression_level,
-        max_payload_read: options.max_payload_read.unwrap_or(MAX_PAYLOAD_READ),
-        max_read_buffer,
-        utf8: options.check_utf8,
-        fragmentation: options.fragmentation.clone(),
-        max_backpressure_write_boundary: options.max_backpressure_write_boundary,
-    })
+    Negotiation::new(extensions, &options, Role::Client)
 }
 
 fn generate_key() -> String {
@@ -1526,34 +1444,32 @@ mod tests {
     ) -> (WebSocket<MockStream>, WebSocket<MockStream>) {
         let (client_stream, server_stream) = MockStream::pair(buffer_size);
 
-        let extensions = compression_level.map(|_level| WebSocketExtensions {
-            server_max_window_bits: None,
-            client_max_window_bits: None,
-            server_no_context_takeover: false,
-            client_no_context_takeover: false,
-        });
+        let extensions = compression_level.map(|_level| WebSocketExtensions::default());
 
-        let negotiation = Negotiation {
-            extensions,
-            compression_level,
-            max_payload_read: MAX_PAYLOAD_READ,
-            max_read_buffer: MAX_READ_BUFFER,
-            utf8: false,
-            fragmentation: fragment_size.map(|size| options::Fragmentation {
-                timeout: None,
-                fragment_size: Some(size),
-            }),
-            max_backpressure_write_boundary: None,
-        };
+        let mut options = Options::default();
+        if let Some(level) = compression_level {
+            options = options.with_compression_level(level);
+        }
+        if let Some(size) = fragment_size {
+            options = options.with_max_fragment_size(size);
+        }
+
+        let negotiation =
+            |role| Negotiation::new(extensions.clone(), &options, role).expect("negotiation");
 
         let client_ws = WebSocket::new(
             Role::Client,
             client_stream,
             Bytes::new(),
-            negotiation.clone(),
+            negotiation(Role::Client),
         );
 
-        let server_ws = WebSocket::new(Role::Server, server_stream, Bytes::new(), negotiation);
+        let server_ws = WebSocket::new(
+            Role::Server,
+            server_stream,
+            Bytes::new(),
+            negotiation(Role::Server),
+        );
 
         (client_ws, server_ws)
     }
@@ -1977,27 +1893,22 @@ mod tests {
         // Create WebSocket pair with fragment_size set to 100 bytes
         let (client_stream, server_stream) = MockStream::pair(8192);
 
-        let negotiation = Negotiation {
-            extensions: None,
-            compression_level: None,
-            max_payload_read: MAX_PAYLOAD_READ,
-            max_read_buffer: MAX_READ_BUFFER,
-            utf8: false,
-            fragmentation: Some(options::Fragmentation {
-                timeout: None,
-                fragment_size: Some(100),
-            }),
-            max_backpressure_write_boundary: None,
-        };
+        let options = Options::default().with_max_fragment_size(100);
+        let negotiation = |role| Negotiation::new(None, &options, role).expect("negotiation");
 
         let mut client_ws = WebSocket::new(
             Role::Client,
             client_stream,
             Bytes::new(),
-            negotiation.clone(),
+            negotiation(Role::Client),
         );
 
-        let mut server_ws = WebSocket::new(Role::Server, server_stream, Bytes::new(), negotiation);
+        let mut server_ws = WebSocket::new(
+            Role::Server,
+            server_stream,
+            Bytes::new(),
+            negotiation(Role::Server),
+        );
 
         // Send a large message (300 bytes) from client
         let large_payload = vec![b'A'; 300];
@@ -2017,27 +1928,22 @@ mod tests {
         // Create WebSocket pair with fragment_size set to 100 bytes
         let (client_stream, server_stream) = MockStream::pair(8192);
 
-        let negotiation = Negotiation {
-            extensions: None,
-            compression_level: None,
-            max_payload_read: MAX_PAYLOAD_READ,
-            max_read_buffer: MAX_READ_BUFFER,
-            utf8: false,
-            fragmentation: Some(options::Fragmentation {
-                timeout: None,
-                fragment_size: Some(100),
-            }),
-            max_backpressure_write_boundary: None,
-        };
+        let options = Options::default().with_max_fragment_size(100);
+        let negotiation = |role| Negotiation::new(None, &options, role).expect("negotiation");
 
         let mut client_ws = WebSocket::new(
             Role::Client,
             client_stream,
             Bytes::new(),
-            negotiation.clone(),
+            negotiation(Role::Client),
         );
 
-        let mut server_ws = WebSocket::new(Role::Server, server_stream, Bytes::new(), negotiation);
+        let mut server_ws = WebSocket::new(
+            Role::Server,
+            server_stream,
+            Bytes::new(),
+            negotiation(Role::Server),
+        );
 
         // Send a small message (50 bytes) from client
         let small_payload = vec![b'B'; 50];
@@ -2057,24 +1963,22 @@ mod tests {
         // Create WebSocket pair WITHOUT fragment_size
         let (client_stream, server_stream) = MockStream::pair(8192);
 
-        let negotiation = Negotiation {
-            extensions: None,
-            compression_level: None,
-            max_payload_read: MAX_PAYLOAD_READ,
-            max_read_buffer: MAX_READ_BUFFER,
-            utf8: false,
-            fragmentation: None,
-            max_backpressure_write_boundary: None,
-        };
+        let options = Options::default();
+        let negotiation = |role| Negotiation::new(None, &options, role).expect("negotiation");
 
         let mut client_ws = WebSocket::new(
             Role::Client,
             client_stream,
             Bytes::new(),
-            negotiation.clone(),
+            negotiation(Role::Client),
         );
 
-        let mut server_ws = WebSocket::new(Role::Server, server_stream, Bytes::new(), negotiation);
+        let mut server_ws = WebSocket::new(
+            Role::Server,
+            server_stream,
+            Bytes::new(),
+            negotiation(Role::Server),
+        );
 
         // Send a large message (1000 bytes) without fragmentation config
         let large_payload = vec![b'C'; 1000];
@@ -2318,6 +2222,191 @@ mod tests {
         assert_eq!(
             received, original_payload,
             "Compressed fragmented payload mismatch"
+        );
+    }
+
+    /// A client that terminates its deflate stream with a final block (BFINAL=1) used to
+    /// spin the server's read task at 100% CPU instead of yielding the message.
+    ///
+    /// The read runs on a detached thread with its own runtime: the spin never yields, so
+    /// it can neither be cancelled from within its own task nor joined at runtime
+    /// shutdown. Going through a channel lets a regression fail on the timeout instead of
+    /// hanging the whole test run.
+    ///
+    /// See https://github.com/infinitefield/yawc/issues/40
+    #[test]
+    fn test_final_block_compressed_frame_does_not_spin() {
+        use std::sync::mpsc;
+        use std::time::Duration;
+        use tokio::io::AsyncWriteExt;
+
+        const TEXT: &str = r#"[2,"35364f26","TransactionEvent",{"eventType":"Started"}]"#;
+
+        for client_no_context_takeover in [false, true] {
+            let extensions = WebSocketExtensions {
+                client_no_context_takeover,
+                ..Default::default()
+            };
+            let options = Options::default()
+                .with_compression_level(CompressionLevel::default())
+                .with_utf8();
+            let negotiation =
+                Negotiation::new(Some(extensions), &options, Role::Server).expect("negotiation");
+
+            let (mut raw_client, server_stream) = MockStream::pair(4096);
+            let mut server = WebSocket::new(Role::Server, server_stream, Bytes::new(), negotiation);
+
+            // Compress the way the reporter's client does: finish the deflate stream
+            // (BFINAL=1) and leave trailing bytes the inflater can never consume.
+            let mut encoder = flate2::Compress::new(flate2::Compression::default(), false);
+            let mut payload = vec![0u8; 512];
+            encoder
+                .compress(TEXT.as_bytes(), &mut payload, flate2::FlushCompress::Finish)
+                .expect("compression failed");
+            payload.truncate(encoder.total_out() as usize);
+            payload.extend_from_slice(&[0x0b, 0x5b, 0xb9, 0x68]);
+            assert!(payload.len() < 126, "frame length must fit the 7-bit form");
+
+            // FIN + RSV1 + Text, masked as a client frame.
+            let mask = [0xa1, 0x15, 0x93, 0xf5];
+            let mut bytes = vec![0xc1, 0x80 | payload.len() as u8];
+            bytes.extend_from_slice(&mask);
+            bytes.extend(
+                payload
+                    .iter()
+                    .enumerate()
+                    .map(|(i, byte)| byte ^ mask[i % 4]),
+            );
+
+            let (tx, rx) = mpsc::channel();
+            std::thread::spawn(move || {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .expect("runtime");
+
+                let result = runtime.block_on(async move {
+                    raw_client.write_all(&bytes).await.expect("write frame");
+                    raw_client.flush().await.expect("flush frame");
+
+                    let frame = server.next_frame().await?;
+                    Ok::<_, WebSocketError>((frame.opcode(), frame.payload().to_vec()))
+                });
+
+                let _ = tx.send(result);
+            });
+
+            let (opcode, payload) = rx
+                .recv_timeout(Duration::from_secs(10))
+                .expect("server read spun instead of returning (issue #40)")
+                .expect("failed to receive frame");
+
+            assert_eq!(opcode, OpCode::Text);
+            assert_eq!(payload, TEXT.as_bytes());
+        }
+    }
+
+    /// Deflating already-compressed data costs the most CPU of any input and makes the
+    /// frame larger, so `skip_incompressible` sends it as-is. The peer must still
+    /// receive it intact, and compressible traffic must be unaffected.
+    #[tokio::test]
+    async fn test_skip_incompressible_round_trip() {
+        fn negotiation(skip_incompressible: bool, role: Role) -> Negotiation {
+            let mut options =
+                Options::default().with_compression_level(CompressionLevel::default());
+            if skip_incompressible {
+                options = options.skip_incompressible();
+            }
+            Negotiation::new(Some(WebSocketExtensions::default()), &options, role)
+                .expect("negotiation")
+        }
+
+        // Deterministic high-entropy payload, as an already-compressed body would be.
+        let mut state = 0x2545_f491_4f6c_dd1du64;
+        let incompressible: Vec<u8> = (0..8192)
+            .map(|_| {
+                state ^= state << 13;
+                state ^= state >> 7;
+                state ^= state << 17;
+                state as u8
+            })
+            .collect();
+        let compressible = b"the quick brown fox jumps over the lazy dog. ".repeat(200);
+
+        for skip in [false, true] {
+            let (client_stream, server_stream) = MockStream::pair(1 << 16);
+            let mut client = WebSocket::new(
+                Role::Client,
+                client_stream,
+                Bytes::new(),
+                negotiation(skip, Role::Client),
+            );
+            let mut server = WebSocket::new(
+                Role::Server,
+                server_stream,
+                Bytes::new(),
+                negotiation(skip, Role::Server),
+            );
+
+            for payload in [incompressible.clone(), compressible.clone()] {
+                client
+                    .send(Frame::binary(payload.clone()))
+                    .await
+                    .expect("send failed");
+
+                let frame = server.next_frame().await.expect("receive failed");
+                assert_eq!(frame.opcode(), OpCode::Binary);
+                assert_eq!(
+                    frame.payload(),
+                    &payload[..],
+                    "payload corrupted with skip_incompressible={skip}"
+                );
+            }
+        }
+    }
+
+    /// A server must not be able to switch compression on for a client that never
+    /// offered it. This reached an unwrap and panicked the client task before the
+    /// negotiation was resolved in one place.
+    ///
+    /// RFC 6455, Section 4.1: a client must fail the connection when the response
+    /// indicates an extension that was not present in its handshake.
+    #[tokio::test]
+    async fn test_unoffered_compression_fails_handshake() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        const HANDSHAKE: &[u8] = b"HTTP/1.1 101 Switching Protocols\r\n\
+            upgrade: websocket\r\n\
+            connection: upgrade\r\n\
+            sec-websocket-accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\
+            sec-websocket-extensions: permessage-deflate\r\n\
+            \r\n";
+
+        let (client_io, mut peer) = tokio::io::duplex(4096);
+        tokio::spawn(async move {
+            let mut request = Vec::new();
+            let mut byte = [0u8; 1];
+            while !request.ends_with(b"\r\n\r\n") {
+                match peer.read(&mut byte).await {
+                    Ok(0) | Err(_) => return,
+                    Ok(_) => request.push(byte[0]),
+                }
+            }
+            let _ = peer.write_all(HANDSHAKE).await;
+            // Hold the connection open so the failure comes from the negotiation.
+            std::future::pending::<()>().await;
+        });
+
+        // Compression is not enabled on this side.
+        let options = Options::default();
+        assert!(options.compression.is_none());
+
+        let result =
+            WebSocket::handshake("ws://localhost/".parse().expect("url"), client_io, options).await;
+
+        assert!(
+            matches!(result, Err(WebSocketError::CompressionNotSupported)),
+            "expected the handshake to fail, got a different outcome"
         );
     }
 }

--- a/src/native/options.rs
+++ b/src/native/options.rs
@@ -305,6 +305,24 @@ impl Options {
         }
     }
 
+    /// Sends messages that are already compressed without deflating them again.
+    ///
+    /// See [`DeflateOptions::skip_incompressible`]. Enables compression with default
+    /// settings if it is not configured yet.
+    ///
+    /// # Example
+    /// ```
+    /// use yawc::Options;
+    ///
+    /// let options = Options::default().skip_incompressible();
+    /// ```
+    pub fn skip_incompressible(mut self) -> Self {
+        let mut compression = self.compression.unwrap_or_default();
+        compression.skip_incompressible = true;
+        self.compression = Some(compression);
+        self
+    }
+
     /// Disables compression for the WebSocket connection.
     ///
     /// Removes any previously configured compression settings, ensuring that
@@ -638,6 +656,21 @@ pub struct DeflateOptions {
     /// When `true`, compression state is reset after each message, reducing
     /// memory usage at the cost of compression efficiency.
     pub client_no_context_takeover: bool,
+
+    /// Sends messages that are already compressed without deflating them again.
+    ///
+    /// permessage-deflate applies per message (RFC 7692, Section 6), so a sender may
+    /// leave RSV1 unset on any message it chooses. Deflating already-compressed data
+    /// (images, video, archives) is the most expensive input there is and makes the
+    /// frame larger, so this samples large payloads and sends them as-is when they
+    /// look high-entropy.
+    ///
+    /// Applies only to complete, unfragmented messages: a fragment in the middle of a
+    /// message shares its deflate stream with the fragments around it and cannot opt
+    /// out on its own.
+    ///
+    /// `false` by default, since it changes which messages carry RSV1.
+    pub skip_incompressible: bool,
 }
 
 impl DeflateOptions {
@@ -657,6 +690,7 @@ impl DeflateOptions {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         }
     }
 
@@ -676,6 +710,7 @@ impl DeflateOptions {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         }
     }
 
@@ -696,6 +731,7 @@ impl DeflateOptions {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         }
     }
 
@@ -762,6 +798,7 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -787,6 +824,7 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: true,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -812,6 +850,7 @@ mod tests {
             client_max_window_bits: Some(15),
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -839,6 +878,7 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -866,6 +906,7 @@ mod tests {
             client_max_window_bits: Some(13),
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -893,6 +934,7 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -918,6 +960,7 @@ mod tests {
             client_max_window_bits: Some(14),
             server_no_context_takeover: true,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         #[cfg(not(feature = "zlib"))]
@@ -925,6 +968,7 @@ mod tests {
             level: CompressionLevel::default(),
             server_no_context_takeover: true,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         #[cfg(feature = "zlib")]
@@ -973,6 +1017,7 @@ mod tests {
             client_max_window_bits: Some(13),
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -998,6 +1043,7 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
+            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -1035,6 +1081,7 @@ mod tests {
                 client_max_window_bits: Some(12), // Server prefers 12
                 server_no_context_takeover: false,
                 client_no_context_takeover: false,
+                skip_incompressible: false,
             };
 
             let merged = server.merge(&client_offer);
@@ -1056,6 +1103,7 @@ mod tests {
                 level: CompressionLevel::default(),
                 server_no_context_takeover: false,
                 client_no_context_takeover: false,
+                skip_incompressible: false,
             };
 
             let merged = server.merge(&client_offer);

--- a/src/native/options.rs
+++ b/src/native/options.rs
@@ -305,24 +305,6 @@ impl Options {
         }
     }
 
-    /// Sends messages that are already compressed without deflating them again.
-    ///
-    /// See [`DeflateOptions::skip_incompressible`]. Enables compression with default
-    /// settings if it is not configured yet.
-    ///
-    /// # Example
-    /// ```
-    /// use yawc::Options;
-    ///
-    /// let options = Options::default().skip_incompressible();
-    /// ```
-    pub fn skip_incompressible(mut self) -> Self {
-        let mut compression = self.compression.unwrap_or_default();
-        compression.skip_incompressible = true;
-        self.compression = Some(compression);
-        self
-    }
-
     /// Disables compression for the WebSocket connection.
     ///
     /// Removes any previously configured compression settings, ensuring that
@@ -656,21 +638,6 @@ pub struct DeflateOptions {
     /// When `true`, compression state is reset after each message, reducing
     /// memory usage at the cost of compression efficiency.
     pub client_no_context_takeover: bool,
-
-    /// Sends messages that are already compressed without deflating them again.
-    ///
-    /// permessage-deflate applies per message (RFC 7692, Section 6), so a sender may
-    /// leave RSV1 unset on any message it chooses. Deflating already-compressed data
-    /// (images, video, archives) is the most expensive input there is and makes the
-    /// frame larger, so this samples large payloads and sends them as-is when they
-    /// look high-entropy.
-    ///
-    /// Applies only to complete, unfragmented messages: a fragment in the middle of a
-    /// message shares its deflate stream with the fragments around it and cannot opt
-    /// out on its own.
-    ///
-    /// `false` by default, since it changes which messages carry RSV1.
-    pub skip_incompressible: bool,
 }
 
 impl DeflateOptions {
@@ -690,7 +657,6 @@ impl DeflateOptions {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         }
     }
 
@@ -710,7 +676,6 @@ impl DeflateOptions {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         }
     }
 
@@ -731,7 +696,6 @@ impl DeflateOptions {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         }
     }
 
@@ -798,7 +762,6 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -824,7 +787,6 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: true,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -850,7 +812,6 @@ mod tests {
             client_max_window_bits: Some(15),
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -878,7 +839,6 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -906,7 +866,6 @@ mod tests {
             client_max_window_bits: Some(13),
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -934,7 +893,6 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -960,7 +918,6 @@ mod tests {
             client_max_window_bits: Some(14),
             server_no_context_takeover: true,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         #[cfg(not(feature = "zlib"))]
@@ -968,7 +925,6 @@ mod tests {
             level: CompressionLevel::default(),
             server_no_context_takeover: true,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         #[cfg(feature = "zlib")]
@@ -1017,7 +973,6 @@ mod tests {
             client_max_window_bits: Some(13),
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -1043,7 +998,6 @@ mod tests {
             client_max_window_bits: None,
             server_no_context_takeover: false,
             client_no_context_takeover: false,
-            skip_incompressible: false,
         };
 
         let client_offer = WebSocketExtensions {
@@ -1081,7 +1035,6 @@ mod tests {
                 client_max_window_bits: Some(12), // Server prefers 12
                 server_no_context_takeover: false,
                 client_no_context_takeover: false,
-                skip_incompressible: false,
             };
 
             let merged = server.merge(&client_offer);
@@ -1103,7 +1056,6 @@ mod tests {
                 level: CompressionLevel::default(),
                 server_no_context_takeover: false,
                 client_no_context_takeover: false,
-                skip_incompressible: false,
             };
 
             let merged = server.merge(&client_offer);

--- a/src/native/streaming.rs
+++ b/src/native/streaming.rs
@@ -162,8 +162,6 @@ pub struct Streaming<S> {
     deflate: Option<Compressor>,
     // decompressor
     inflate: Option<Decompressor>,
-    // skip deflating payloads that are already compressed
-    skip_incompressible: bool,
 }
 
 impl<S> Streaming<S>
@@ -192,7 +190,6 @@ where
             flush_sends: false,
             deflate: negotiated.compressor(),
             inflate: negotiated.decompressor(),
-            skip_incompressible: negotiated.skip_incompressible(),
         }
     }
 
@@ -418,22 +415,10 @@ where
         let should_compress = !item.opcode.is_control();
         if should_compress {
             if let Some(deflate) = this.deflate.as_mut() {
-                // Only a complete, unfragmented message may opt out: a fragment shares
-                // its deflate stream with the fragments around it, so skipping one
-                // would corrupt the message. `streaming` is still the state left by the
-                // previous frame at this point, so it tells us whether one is in flight.
-                let skip = this.skip_incompressible
-                    && !this.write_half.streaming
-                    && item.is_fin()
-                    && item.payload.len() >= crate::compression::INCOMPRESSIBLE_MIN_LEN
-                    && crate::compression::looks_incompressible(&item.payload);
-
-                if !skip {
-                    let output = deflate.compress(&item.payload, item.is_fin())?;
-                    // Set the RSV1 bit only when we are not streaming
-                    item.is_compressed = !this.write_half.streaming;
-                    item.payload = output;
-                }
+                let output = deflate.compress(&item.payload, item.is_fin())?;
+                // Set the RSV1 bit only when we are not streaming
+                item.is_compressed = !this.write_half.streaming;
+                item.payload = output;
             }
         }
 

--- a/src/native/streaming.rs
+++ b/src/native/streaming.rs
@@ -162,6 +162,8 @@ pub struct Streaming<S> {
     deflate: Option<Compressor>,
     // decompressor
     inflate: Option<Decompressor>,
+    // skip deflating payloads that are already compressed
+    skip_incompressible: bool,
 }
 
 impl<S> Streaming<S>
@@ -188,8 +190,9 @@ where
             wake_proxy: Arc::new(WakeProxy::default()),
             obligated_sends: VecDeque::new(),
             flush_sends: false,
-            deflate: negotiated.compressor(role),
-            inflate: negotiated.decompressor(role),
+            deflate: negotiated.compressor(),
+            inflate: negotiated.decompressor(),
+            skip_incompressible: negotiated.skip_incompressible(),
         }
     }
 
@@ -415,10 +418,22 @@ where
         let should_compress = !item.opcode.is_control();
         if should_compress {
             if let Some(deflate) = this.deflate.as_mut() {
-                let output = deflate.compress(&item.payload, item.is_fin())?;
-                // Set the RSV1 bit only when we are not streaming
-                item.is_compressed = !this.write_half.streaming;
-                item.payload = output;
+                // Only a complete, unfragmented message may opt out: a fragment shares
+                // its deflate stream with the fragments around it, so skipping one
+                // would corrupt the message. `streaming` is still the state left by the
+                // previous frame at this point, so it tells us whether one is in flight.
+                let skip = this.skip_incompressible
+                    && !this.write_half.streaming
+                    && item.is_fin()
+                    && item.payload.len() >= crate::compression::INCOMPRESSIBLE_MIN_LEN
+                    && crate::compression::looks_incompressible(&item.payload);
+
+                if !skip {
+                    let output = deflate.compress(&item.payload, item.is_fin())?;
+                    // Set the RSV1 bit only when we are not streaming
+                    item.is_compressed = !this.write_half.streaming;
+                    item.payload = output;
+                }
             }
         }
 

--- a/src/native/upgrade.rs
+++ b/src/native/upgrade.rs
@@ -15,7 +15,7 @@ use super::{HttpStream, Negotiation, Role, WebSocket};
 
 #[cfg(feature = "axum")]
 use {
-    super::{Options, MAX_PAYLOAD_READ, MAX_READ_BUFFER},
+    super::Options,
     crate::{compression::WebSocketExtensions, Result},
     http_body_util::Empty,
     hyper::{header, Response},
@@ -150,28 +150,9 @@ impl IncomingUpgrade {
             .body(Empty::new())
             .expect("bug: failed to build response");
 
-        // max read buffer should be at least 2 times the payload read if not specified
-        let max_read_buffer = options.max_read_buffer.unwrap_or(
-            options
-                .max_payload_read
-                .map(|payload_read| payload_read * 2)
-                .unwrap_or(MAX_READ_BUFFER),
-        );
-
         let stream = UpgradeFut {
             inner: self.on_upgrade,
-            negotiation: Some(Negotiation {
-                extensions,
-                compression_level: options
-                    .compression
-                    .as_ref()
-                    .map(|compression| compression.level),
-                max_payload_read: options.max_payload_read.unwrap_or(MAX_PAYLOAD_READ),
-                max_backpressure_write_boundary: options.max_backpressure_write_boundary,
-                fragmentation: options.fragmentation.clone(),
-                max_read_buffer,
-                utf8: options.check_utf8,
-            }),
+            negotiation: Some(Negotiation::new(extensions, &options, Role::Server)?),
         };
 
         Ok((response, stream))


### PR DESCRIPTION
Fixes #40.

## The hang

A peer that ends its deflate stream with a final block (BFINAL=1) leaves bytes the inflater can never consume. `Inflate::write` fed input until the slice was empty, so once zlib reported `StreamEnd` it retried the same bytes forever, never yielding to the executor. One core per affected connection, until the process is killed.

Any peer can trigger it, so this is a remote DoS, not only a compatibility bug. Minimised by the fuzzer, four bytes are enough:

```
c2 02 03 80
```

A binary frame whose two-byte payload is an empty final block. The reporter hit it with an ordinary OCPP client whose message decodes fine (a 586-byte `TransactionEvent`); their client just finishes its deflate stream and leaves four trailing bytes.

The fix stops consuming on `StreamEnd`, drops the unconsumable remainder, and resets the context so later messages still decompress. A peer that does this is effectively running with no context takeover. A no-progress guard covers any other state where the inflater stops advancing, so this class of hang cannot return quietly.

Reproduced before fixing: the regression test hangs until killed on both deflate backends (miniz_oxide and zlib-rs) and passes after.

## Also in this PR

**Compression config resolved once.** `Negotiation` was assembled field by field in four places and the role branching was written out four times, of which only one clamped the window bits. A peer could negotiate `client_max_window_bits=8` and reach flate2 unclamped on three of the four paths. `CompressionConfig` now resolves the negotiated parameters once with the role to direction mapping applied, and `Negotiation::new` is the only way to build one. `upgrade.rs` goes from 21 lines of field copying to 2. That duplication is exactly how a field came to be missing from the axum path while the other three had it.

**A remotely triggerable panic.** A server returning `permessage-deflate` to a client that never offered it left the level unset and hit `self.compression_level.unwrap()`. RFC 6455 section 4.1 requires a client to fail the connection in that case, so it now returns `WebSocketError::CompressionNotSupported`. Reusing the existing variant keeps the public API unchanged.

`Compressor`/`Decompressor` also lose their `Contextual`/`NoContextTakeover` enums in favour of a flag, which removes the parallel `compress`/`compress_no_context` method pairs.

There is no public API change in this PR.

## Fuzzing

`cargo make fuzz` runs two libFuzzer targets (nightly, so not part of `ci`): `frame_decode` and `websocket_read`. With `-timeout`, libFuzzer reports a non-terminating input the same way as a crash, which is what makes it the right tool for this bug. Against the unpatched code it finds the hang in seconds.

One caveat worth knowing when reading `websocket_read`: its peer reads the request before answering. hyper rejects a response that arrives before it has sent one, and without that the handshake fails on every run, so the target reports millions of clean runs while covering nothing (`cov: 1746, corp: 4/4b` frozen for 1.3M runs). Fixed, it reaches `cov: 3701 ft: 7496 corp: 576`.

Seeded `test_fuzz_*` tests in `src/compression.rs` cover the same properties on every CI run without nightly. Each batch runs on its own thread behind a watchdog, since a spinning loop never yields and so cannot be caught by an assertion inside the case; failures name the iteration and seed that reproduce them.

## Tests

15 tests added. Beyond the regression tests for the hang (including the reporter's exact payload and the fuzzer-minimised case): role to direction mapping pinned in both directions, since a swapped `client_`/`server_` would still round-trip against yawc itself; window-bit clamping across `[0, 1, 7, 8, 16, 255]` by both roles and both directions; the unoffered-extension error; and an end-to-end handshake test for the panic. Existing helpers now build through `Negotiation::new` instead of struct literals, so they exercise the real `Options` mapping.

Verified on default features, `--features zlib`, and `--all-features` (112 tests plus 57 doc tests), with `cargo fmt --check` and `clippy --all-features --lib --tests --examples -D warnings` clean.

## Not covered

The autobahn suite has not been run; it needs Docker, which was not available here. It is the one thing that would independently validate the enum collapse and the clamp against a real peer, so it is worth a `cargo make ci` before release.

## Notes for review

An earlier revision of this branch added a `skip_incompressible` option that sampled payload entropy to avoid deflating already-compressed data. It is removed in 9b15be2: the threshold was empirical, the estimate is biased on a small sample, and a wrong answer is invisible, since a compressible message would go out uncompressed with nothing reporting it. If that optimisation is worth having, it belongs as an explicit per-message opt-out, because the application already knows whether it is sending images.

The first commit bundles the hang fix and the refactor. They touch overlapping regions of `src/compression.rs`, and splitting them would have meant reconstructing intermediate states by hand with a real chance of committing something that does not build. Happy to restructure if you would rather review them separately.

One behaviour change to weigh: a client now returns an error instead of panicking on an unoffered extension. It aborted the task either way, so nothing that worked before stops working.
