### PR TITLE
Support WebSockets over HTTP/2 (RFC 8441)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,10 @@ jobs:
         run: cargo test --verbose
       - name: Test zlib
         run: cargo test --verbose --features zlib
+      - name: Test axum
+        # Without http2, so the axum extractor is covered in the same shape the autobahn
+        # suite builds it: extended CONNECT compiled out.
+        run: cargo test --verbose --features axum,zlib
       - name: Test http2
         # axum comes along because the RFC 8441 extractor test needs both features.
         run: cargo test --verbose --features http2,axum

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -30,6 +30,9 @@ jobs:
         run: cargo test --verbose
       - name: Test zlib
         run: cargo test --verbose --features zlib
+      - name: Test http2
+        # axum comes along because the RFC 8441 extractor test needs both features.
+        run: cargo test --verbose --features http2,axum
       - name: Test WASM
         run: |
           env WASM_BINDGEN_USE_BROWSER=1 wasm-pack test --headless --chrome --lib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   using extended CONNECT instead of the HTTP/1.1 `Upgrade` handshake. Only the handshake
   changes; framing, masking and permessage-deflate are unchanged.
   - Client: `WebSocket::connect(url).http_version(HttpVersion::Http2 | Auto | Http1)`.
-    `Auto` negotiates over ALPN and falls back to HTTP/1.1.
+    `Auto` offers both over ALPN, and if the peer picks `h2` but then refuses the
+    extended CONNECT, retries over HTTP/1.1 on a fresh connection. Negotiating `h2` only
+    means the peer speaks HTTP/2, not that it implements RFC 8441, so against most
+    deployments that retry is the normal path rather than an edge case.
   - Server: `WebSocket::upgrade` and `WebSocket::upgrade_with_options` detect extended
     CONNECT and take the HTTP/2 path, so one handler serves both versions. The hyper
     HTTP/2 server builder must have `enable_connect_protocol()` set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New `http2` feature**: Carries WebSocket connections over a single HTTP/2 stream
   using extended CONNECT instead of the HTTP/1.1 `Upgrade` handshake. Only the handshake
   changes; framing, masking and permessage-deflate are unchanged.
-  - Client: `WebSocket::connect(url).http_version(HttpVersion::Http2 | Auto | Http1)`.
-    `Auto` offers both over ALPN, and if the peer picks `h2` but then refuses the
-    extended CONNECT, retries over HTTP/1.1 on a fresh connection. Negotiating `h2` only
-    means the peer speaks HTTP/2, not that it implements RFC 8441, so against most
-    deployments that retry is the normal path rather than an edge case.
+  - Client: `WebSocket::connect(url).http_version(HttpVersion::Http2)`. HTTP/1.1 stays
+    the default, so existing code is unaffected. There is no automatic negotiation:
+    agreeing on `h2` over ALPN says the peer speaks HTTP/2, not that it implements RFC
+    8441, and most deployments serve `h2` for ordinary requests while accepting
+    WebSockets over HTTP/1.1 only. Asking for HTTP/2 against such a peer fails rather
+    than silently downgrading.
   - Server: `WebSocket::upgrade` and `WebSocket::upgrade_with_options` detect extended
     CONNECT and take the HTTP/2 path, so one handler serves both versions. The hyper
     HTTP/2 server builder must have `enable_connect_protocol()` set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     CONNECT and take the HTTP/2 path, so one handler serves both versions. The hyper
     HTTP/2 server builder must have `enable_connect_protocol()` set.
   - The axum `IncomingUpgrade` extractor accepts both handshakes.
-  - New errors `ExtendedConnectNotSupported` and `MissingConnectProtocol`.
+  - New error `ExtendedConnectNotSupported`.
   - See the `http2_client` and `http2_server` examples.
 
 - **New `WebSocket::from_stream` and `WebSocket::from_stream_with_extensions`**: Wrap a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### WebSockets over HTTP/2 (RFC 8441)
+
+- **New `http2` feature**: Carries WebSocket connections over a single HTTP/2 stream
+  using extended CONNECT instead of the HTTP/1.1 `Upgrade` handshake. Only the handshake
+  changes; framing, masking and permessage-deflate are unchanged.
+  - Client: `WebSocket::connect(url).http_version(HttpVersion::Http2 | Auto | Http1)`.
+    `Auto` negotiates over ALPN and falls back to HTTP/1.1.
+  - Server: `WebSocket::upgrade` and `WebSocket::upgrade_with_options` detect extended
+    CONNECT and take the HTTP/2 path, so one handler serves both versions. The hyper
+    HTTP/2 server builder must have `enable_connect_protocol()` set.
+  - The axum `IncomingUpgrade` extractor accepts both handshakes.
+  - New errors `ExtendedConnectNotSupported` and `MissingConnectProtocol`.
+  - See the `http2_client` and `http2_server` examples.
+
+- **New `WebSocket::from_stream` and `WebSocket::from_stream_with_extensions`**: Wrap a
+  stream that has already completed a handshake elsewhere. Available regardless of
+  feature flags.
+
 #### Streaming API
 
 - **New `Streaming` type**: Low-level WebSocket API with manual fragment control

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ anyhow = "1"
 axum = "0.8"
 console-subscriber = "0.5.0"
 hyper = { version = "1.11", features = ["http1", "http2", "server", "client"] }
-hyper-util = { version = "0.1", features = ["tokio"] }
+hyper-util = { version = "0.1", features = ["tokio", "service"] }
 log = "0.4"
 reqwest = { version = "0.13" }
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,11 +40,23 @@ axum = ["axum-core", "http"]
 rustls-ring = ["tokio-rustls/ring"]
 rustls-aws-lc-rs = ["tokio-rustls/aws-lc-rs"]
 smol = ["dep:smol"]
+# WebSockets over HTTP/2 (RFC 8441)
+http2 = ["hyper/http2", "dep:h2"]
 
 # Examples configuration
 [[example]]
 name = "axum"
 required-features = ["axum"]
+test = false
+
+[[example]]
+name = "http2_client"
+required-features = ["http2"]
+test = false
+
+[[example]]
+name = "http2_server"
+required-features = ["http2"]
 test = false
 
 [[example]]
@@ -125,8 +137,10 @@ tokio = { version = "1", default-features = false }
 # ==============================================================================
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # HTTP clients
-hyper = { version = "1", features = ["client", "http1"] }
+hyper = { version = "1.11", features = ["client", "http1"] }
 hyper-util = { version = "0.1", features = ["tokio"] }
+# Only to classify HTTP/2 stream errors during the RFC 8441 handshake.
+h2 = { version = "0.4", optional = true }
 tokio-rustls = { version = "0.26", default-features = false, features = [
     "logging",
     "tls12",
@@ -181,7 +195,8 @@ wasm-bindgen-test = "0.3"
 anyhow = "1"
 axum = "0.8"
 console-subscriber = "0.5.0"
-hyper = { version = "1.7", features = ["http1", "server", "client"] }
+hyper = { version = "1.11", features = ["http1", "http2", "server", "client"] }
+hyper-util = { version = "0.1", features = ["tokio"] }
 log = "0.4"
 reqwest = { version = "0.13" }
 serde = { version = "1", features = ["derive"] }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -98,10 +98,11 @@ fi
 '''
 
 [tasks.test-http2]
-description = "Run the test suite with the http2 feature (nextest if available)"
+description = "Run the test suite with the http2 and axum features (nextest if available)"
 # Doc tests run in `test` above. This adds the RFC 8441 unit and integration
-# tests, which are compiled out without the feature.
-env = { "YAWC_TEST_FEATURES" = "--features http2", "YAWC_TEST_DOC" = "0" }
+# tests, which are compiled out without the feature. axum comes along because the
+# extractor test needs both features to compile.
+env = { "YAWC_TEST_FEATURES" = "--features http2,axum", "YAWC_TEST_DOC" = "0" }
 run_task = "test-runner"
 
 [tasks.wasm]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -97,6 +97,13 @@ else
 fi
 '''
 
+[tasks.test-axum]
+description = "Run the test suite with axum and zlib, without http2 (nextest if available)"
+# Matches how the autobahn suite builds the server, so the axum extractor is covered
+# with the extended-CONNECT branch compiled out.
+env = { "YAWC_TEST_FEATURES" = "--features axum,zlib", "YAWC_TEST_DOC" = "0" }
+run_task = "test-runner"
+
 [tasks.test-http2]
 description = "Run the test suite with the http2 and axum features (nextest if available)"
 # Doc tests run in `test` above. This adds the RFC 8441 unit and integration
@@ -158,6 +165,7 @@ dependencies = [
     "build",
     "test",
     "test-zlib",
+    "test-axum",
     "test-http2",
     "doc",
     "wasm",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -97,6 +97,13 @@ else
 fi
 '''
 
+[tasks.test-http2]
+description = "Run the test suite with the http2 feature (nextest if available)"
+# Doc tests run in `test` above. This adds the RFC 8441 unit and integration
+# tests, which are compiled out without the feature.
+env = { "YAWC_TEST_FEATURES" = "--features http2", "YAWC_TEST_DOC" = "0" }
+run_task = "test-runner"
+
 [tasks.wasm]
 description = "Run the wasm tests in headless chrome and node"
 script_runner = "@shell"
@@ -150,6 +157,7 @@ dependencies = [
     "build",
     "test",
     "test-zlib",
+    "test-http2",
     "doc",
     "wasm",
     "autobahn-client",

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ yawc stands apart as the **most flexible and feature-complete WebSocket library*
 - **Flow Control**: Configurable backpressure boundaries and automatic fragmentation for large messages
 - **Autobahn Test Suite**: Passes all test cases for both client and server modes
 - **WebAssembly Support**: Works seamlessly in WASM environments for browser-based applications (both text and binary modes supported)
+- **HTTP/2 (RFC 8441)**: Optional extended CONNECT handshake for client and server, behind the `http2` feature
 
 ## About compression
 
@@ -201,6 +202,7 @@ These examples serve as practical reference implementations for common WebSocket
 
 - `reqwest`: Use reqwest as the HTTP client
 - `axum`: Enable integration with the Axum web framework
+- `http2`: Enable WebSockets over HTTP/2 via extended CONNECT (RFC 8441)
 - `logging`: Enable debug logging for connection events
 - `zlib`: Enable advanced compression options with zlib (not recommended unless you know what you are doing). Without this option, yawc will use miniz_oxide, a Rust deflate implementation.
 - `rustls-ring`: Enable the fallback rustls crypto provider based on `ring`

--- a/examples/http2_client.rs
+++ b/examples/http2_client.rs
@@ -12,9 +12,10 @@
 //! cargo run --features http2 --example http2_client
 //! ```
 //!
-//! Pass a `wss://` URL as the first argument to talk to a real endpoint, in which case
-//! [`HttpVersion::Auto`] negotiates HTTP/2 over ALPN and quietly falls back to HTTP/1.1
-//! when the server does not support RFC 8441.
+//! Pass a `wss://` URL as the first argument to talk to a real endpoint. Note that this
+//! fails against a server that does not implement RFC 8441, which is most of them: the
+//! HTTP/2 handshake is opt-in and does not fall back. Drop the `http_version` call to use
+//! the default HTTP/1.1 handshake instead.
 
 use futures::{SinkExt, StreamExt};
 use yawc::{frame::OpCode, Frame, HttpVersion, Options, WebSocket};
@@ -25,16 +26,10 @@ async fn main() -> anyhow::Result<()> {
         .nth(1)
         .unwrap_or_else(|| "ws://127.0.0.1:9002/chat".to_string());
 
-    // Plaintext has no ALPN to negotiate with, so it needs HTTP/2 prior knowledge.
-    // Anything over TLS can let ALPN decide.
-    let version = if url.starts_with("wss://") {
-        HttpVersion::Auto
-    } else {
-        HttpVersion::Http2
-    };
-
+    // Over plaintext this is HTTP/2 prior knowledge; over TLS it offers only the h2 ALPN
+    // protocol. Either way the peer has to implement RFC 8441 or the connection fails.
     let mut ws = WebSocket::connect(url.parse()?)
-        .http_version(version)
+        .http_version(HttpVersion::Http2)
         .with_options(Options::default().with_balanced_compression())
         .await?;
 

--- a/examples/http2_client.rs
+++ b/examples/http2_client.rs
@@ -1,0 +1,64 @@
+//! WebSocket client over HTTP/2 (RFC 8441).
+//!
+//! Start the server first:
+//!
+//! ```sh
+//! cargo run --features http2 --example http2_server
+//! ```
+//!
+//! then run:
+//!
+//! ```sh
+//! cargo run --features http2 --example http2_client
+//! ```
+//!
+//! Pass a `wss://` URL as the first argument to talk to a real endpoint, in which case
+//! [`HttpVersion::Auto`] negotiates HTTP/2 over ALPN and quietly falls back to HTTP/1.1
+//! when the server does not support RFC 8441.
+
+use futures::{SinkExt, StreamExt};
+use yawc::{frame::OpCode, Frame, HttpVersion, Options, WebSocket};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let url = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "ws://127.0.0.1:9002/chat".to_string());
+
+    // Plaintext has no ALPN to negotiate with, so it needs HTTP/2 prior knowledge.
+    // Anything over TLS can let ALPN decide.
+    let version = if url.starts_with("wss://") {
+        HttpVersion::Auto
+    } else {
+        HttpVersion::Http2
+    };
+
+    let mut ws = WebSocket::connect(url.parse()?)
+        .http_version(version)
+        .with_options(Options::default().with_balanced_compression())
+        .await?;
+
+    println!("connected");
+
+    for i in 0..5 {
+        let message = format!("hello {i}");
+        ws.send(Frame::text(message.clone())).await?;
+        println!("sent:  {message}");
+
+        match ws.next().await {
+            Some(frame) if frame.opcode() == OpCode::Text => {
+                println!("recv:  {}", String::from_utf8_lossy(frame.payload()));
+            }
+            Some(frame) => println!("recv:  {:?} frame", frame.opcode()),
+            None => {
+                println!("connection closed by peer");
+                return Ok(());
+            }
+        }
+    }
+
+    ws.send(Frame::close(yawc::close::CloseCode::Normal, b"done"))
+        .await?;
+
+    Ok(())
+}

--- a/examples/http2_server.rs
+++ b/examples/http2_server.rs
@@ -1,0 +1,90 @@
+//! WebSocket echo server over HTTP/2 (RFC 8441).
+//!
+//! Run with:
+//!
+//! ```sh
+//! cargo run --features http2 --example http2_server
+//! ```
+//!
+//! Then point the matching client at it:
+//!
+//! ```sh
+//! cargo run --features http2 --example http2_client
+//! ```
+//!
+//! The one thing that makes RFC 8441 work is `enable_connect_protocol()` below. It is
+//! what advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`; without it hyper rejects the
+//! extended CONNECT before the handler ever runs.
+//!
+//! This listens over plaintext HTTP/2, which requires clients to use prior knowledge. A
+//! real deployment would terminate TLS and negotiate `h2` over ALPN.
+
+use std::convert::Infallible;
+
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use http_body_util::Empty;
+use hyper::{body::Incoming, server::conn::http2, service::service_fn, Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::net::TcpListener;
+use yawc::{frame::OpCode, Options, WebSocket};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let listener = TcpListener::bind("127.0.0.1:9002").await?;
+    println!("listening on ws://127.0.0.1:9002 (http/2)");
+
+    loop {
+        let (stream, peer) = listener.accept().await?;
+
+        tokio::spawn(async move {
+            let result = http2::Builder::new(TokioExecutor::new())
+                .enable_connect_protocol()
+                .serve_connection(TokioIo::new(stream), service_fn(handle))
+                .await;
+
+            if let Err(err) = result {
+                eprintln!("connection from {peer} failed: {err}");
+            }
+        });
+    }
+}
+
+/// Upgrades the request and echoes messages back.
+///
+/// `upgrade_with_options` picks the handshake from the request, so this same handler also
+/// serves HTTP/1.1 clients if the listener is served with `http1::Builder` instead.
+async fn handle(mut req: Request<Incoming>) -> Result<Response<Empty<Bytes>>, Infallible> {
+    let options = Options::default().with_balanced_compression();
+
+    let (response, fut) = match WebSocket::upgrade_with_options(&mut req, options) {
+        Ok(upgrade) => upgrade,
+        Err(err) => {
+            eprintln!("rejecting handshake: {err}");
+            let mut response = Response::new(Empty::new());
+            *response.status_mut() = hyper::StatusCode::BAD_REQUEST;
+            return Ok(response);
+        }
+    };
+
+    tokio::spawn(async move {
+        let mut ws = match fut.await {
+            Ok(ws) => ws,
+            Err(err) => {
+                eprintln!("upgrade failed: {err}");
+                return;
+            }
+        };
+
+        while let Some(frame) = ws.next().await {
+            if matches!(frame.opcode(), OpCode::Text | OpCode::Binary) {
+                if let Err(err) = ws.send(frame).await {
+                    eprintln!("send failed: {err}");
+                    break;
+                }
+            }
+        }
+    });
+
+    Ok(response)
+}

--- a/src/compression.rs
+++ b/src/compression.rs
@@ -34,6 +34,38 @@ pub struct WebSocketExtensions {
     pub(super) client_no_context_takeover: bool,
 }
 
+impl WebSocketExtensions {
+    /// Reads the `Sec-WebSocket-Extensions` header out of a handshake message.
+    ///
+    /// A missing header and one that fails to parse are both treated as "nothing
+    /// negotiated": the peer offered nothing this side can act on, and the connection
+    /// proceeds without extensions rather than failing. Every handshake path, client and
+    /// server, HTTP/1.1 and HTTP/2, reads the header this way.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn from_headers(headers: &hyper::HeaderMap) -> Option<Self> {
+        use std::str::FromStr;
+
+        headers
+            .get(hyper::header::SEC_WEBSOCKET_EXTENSIONS)
+            .and_then(|value| value.to_str().ok())
+            .map(Self::from_str)
+            .and_then(std::result::Result::ok)
+    }
+
+    /// Resolves what a server should answer with, given what the client offered.
+    ///
+    /// Compression is only negotiated when both sides want it: a client that offered
+    /// nothing gets nothing, and a server with compression disabled ignores whatever was
+    /// offered. Otherwise the two are merged into the terms both can honor.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn agree(server: Option<&DeflateOptions>, client: Option<Self>) -> Option<Self> {
+        match (server, client) {
+            (Some(server), Some(client)) => Some(server.merge(&client)),
+            _ => None,
+        }
+    }
+}
+
 impl<'a> From<&'a DeflateOptions> for WebSocketExtensions {
     /// Converts [`DeflateOptions`] into `WebSocketExtensions`, configuring the extensions
     /// for negotiation based on the specified compression settings.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 //! # Features
 //! - `reqwest`: WebSocket via reqwest HTTP client
 //! - `axum`: WebSocket extractor for axum
+//! - `http2`: WebSockets over HTTP/2 via extended CONNECT (RFC 8441)
 //! - `zlib`: Advanced compression with window size control
 //! - `json`: JSON serialization support
 //!
@@ -70,6 +71,30 @@
 //!     Ok(response)
 //! }
 //! ```
+//!
+//! # WebSockets over HTTP/2
+//!
+//! With the `http2` feature, connections can be carried over a single HTTP/2 stream using
+//! the RFC 8441 extended CONNECT handshake instead of the HTTP/1.1 `Upgrade` handshake.
+//! Only the handshake changes: framing, masking and `permessage-deflate` are the same.
+//!
+//! On the client, pick the version on the builder:
+//!
+//! ```no_run
+//! # #[cfg(feature = "http2")]
+//! async fn connect() -> yawc::Result<()> {
+//!     use yawc::{HttpVersion, WebSocket};
+//!
+//!     let ws = WebSocket::connect("wss://example.com/chat".parse()?)
+//!         .http_version(HttpVersion::Auto)
+//!         .await?;
+//!     Ok(())
+//! }
+//! ```
+//!
+//! On the server, [`WebSocket::upgrade`] handles both handshakes already. The one extra
+//! step is calling `enable_connect_protocol()` on hyper's HTTP/2 server builder, which is
+//! what advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`. See the `http2_server` example.
 
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
@@ -202,6 +227,19 @@ pub enum WebSocketError {
     #[error("Invalid http scheme")]
     InvalidHttpScheme,
 
+    /// The peer does not support RFC 8441 extended CONNECT.
+    ///
+    /// A server that has not advertised `SETTINGS_ENABLE_CONNECT_PROTOCOL` rejects the
+    /// extended CONNECT stream instead of upgrading it.
+    #[error("Peer does not support extended CONNECT (RFC 8441)")]
+    #[cfg(all(feature = "http2", not(target_arch = "wasm32")))]
+    ExtendedConnectNotSupported,
+
+    /// A CONNECT request arrived without `:protocol = websocket`.
+    #[error("CONNECT request is missing the websocket protocol pseudo-header")]
+    #[cfg(all(feature = "http2", not(target_arch = "wasm32")))]
+    MissingConnectProtocol,
+
     /// Received compressed frame but compression not negotiated.
     #[error("Received compressed frame on stream that doesn't support compression")]
     #[cfg(not(target_arch = "wasm32"))]
@@ -254,6 +292,14 @@ impl WebSocketError {
     /// Returns `true` if this is a handshake error.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn is_handshake_error(&self) -> bool {
+        #[cfg(feature = "http2")]
+        if matches!(
+            self,
+            Self::ExtendedConnectNotSupported | Self::MissingConnectProtocol
+        ) {
+            return true;
+        }
+
         matches!(
             self,
             Self::InvalidStatusCode(_)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,11 +242,6 @@ pub enum WebSocketError {
     #[cfg(all(feature = "http2", not(target_arch = "wasm32")))]
     ExtendedConnectNotSupported,
 
-    /// A CONNECT request arrived without `:protocol = websocket`.
-    #[error("CONNECT request is missing the websocket protocol pseudo-header")]
-    #[cfg(all(feature = "http2", not(target_arch = "wasm32")))]
-    MissingConnectProtocol,
-
     /// Received compressed frame but compression not negotiated.
     #[error("Received compressed frame on stream that doesn't support compression")]
     #[cfg(not(target_arch = "wasm32"))]
@@ -300,10 +295,7 @@ impl WebSocketError {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn is_handshake_error(&self) -> bool {
         #[cfg(feature = "http2")]
-        if matches!(
-            self,
-            Self::ExtendedConnectNotSupported | Self::MissingConnectProtocol
-        ) {
+        if matches!(self, Self::ExtendedConnectNotSupported) {
             return true;
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,8 @@
 //! peer speaks HTTP/2, not that it implements RFC 8441, and most deployments serve `h2`
 //! for ordinary requests while accepting WebSockets over HTTP/1.1 only. Choosing HTTP/2
 //! against such a peer fails rather than silently downgrading, so the choice stays with
-//! the caller who knows what the server does.
+//! the caller who knows what the server does. To try HTTP/2 and fall back, see
+//! [`HttpVersion::Http2`].
 //!
 //! On the server, [`WebSocket::upgrade`] handles both handshakes already. The one extra
 //! step is calling `enable_connect_protocol()` on hyper's HTTP/2 server builder, which is

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,7 +78,8 @@
 //! the RFC 8441 extended CONNECT handshake instead of the HTTP/1.1 `Upgrade` handshake.
 //! Only the handshake changes: framing, masking and `permessage-deflate` are the same.
 //!
-//! On the client, pick the version on the builder:
+//! The client stays on HTTP/1.1 unless asked otherwise, so this changes nothing for
+//! existing code. Ask for HTTP/2 explicitly when the server is known to support it:
 //!
 //! ```no_run
 //! # #[cfg(feature = "http2")]
@@ -86,11 +87,17 @@
 //!     use yawc::{HttpVersion, WebSocket};
 //!
 //!     let ws = WebSocket::connect("wss://example.com/chat".parse()?)
-//!         .http_version(HttpVersion::Auto)
+//!         .http_version(HttpVersion::Http2)
 //!         .await?;
 //!     Ok(())
 //! }
 //! ```
+//!
+//! There is deliberately no automatic negotiation. Agreeing on `h2` over ALPN says the
+//! peer speaks HTTP/2, not that it implements RFC 8441, and most deployments serve `h2`
+//! for ordinary requests while accepting WebSockets over HTTP/1.1 only. Choosing HTTP/2
+//! against such a peer fails rather than silently downgrading, so the choice stays with
+//! the caller who knows what the server does.
 //!
 //! On the server, [`WebSocket::upgrade`] handles both handshakes already. The one extra
 //! step is calling `enable_connect_protocol()` on hyper's HTTP/2 server builder, which is

--- a/src/native/builder.rs
+++ b/src/native/builder.rs
@@ -250,10 +250,23 @@ pub enum HttpVersion {
     /// configured to expect it.
     Http2,
 
-    /// Let ALPN decide, preferring HTTP/2.
+    /// Use HTTP/2 where it actually works, otherwise HTTP/1.1.
     ///
-    /// Over `wss://` this offers `h2` and `http/1.1` and follows whatever the server
-    /// picks. Over `ws://` there is nothing to negotiate with, so this is HTTP/1.1.
+    /// Over `wss://` this offers `h2` and `http/1.1` over ALPN. If the server picks `h2`
+    /// but then refuses the extended CONNECT, the connection is retried over HTTP/1.1 on
+    /// a fresh connection, because ALPN has already committed the first one to HTTP/2.
+    ///
+    /// That retry is not a corner case. Negotiating `h2` only says the peer speaks
+    /// HTTP/2, not that it implements RFC 8441, and most deployments serve `h2` for
+    /// ordinary requests while accepting WebSockets over HTTP/1.1 only, so the fallback
+    /// is the common path rather than the exception.
+    ///
+    /// Over `ws://` there is nothing to negotiate with, so this is HTTP/1.1. Prior
+    /// knowledge is not assumed, since it would break an ordinary HTTP/1.1 server.
+    ///
+    /// The cost of the fallback is one extra connection attempt against servers that do
+    /// not support RFC 8441. Use [`HttpVersion::Http1`] to avoid it when the peer is
+    /// known not to, or [`HttpVersion::Http2`] to fail loudly when it should.
     Auto,
 }
 

--- a/src/native/builder.rs
+++ b/src/native/builder.rs
@@ -273,6 +273,39 @@ pub enum HttpVersion {
     /// requests while accepting WebSockets over HTTP/1.1 only. Against such a peer this
     /// fails rather than downgrading, so use it when the server is known to implement
     /// RFC 8441. Everything else should stay on the default HTTP/1.1 handshake.
+    ///
+    /// # Trying HTTP/2 first
+    ///
+    /// There is no built-in negotiation, because ALPN cannot answer whether the peer
+    /// implements RFC 8441 and guessing wrong costs a wasted connection. A caller who
+    /// wants to try anyway can ask for it and fall back:
+    ///
+    /// ```no_run
+    /// use yawc::{HttpVersion, WebSocket};
+    ///
+    /// # async fn example(url: url::Url) -> yawc::Result<()> {
+    /// let ws = match WebSocket::connect(url.clone())
+    ///     .http_version(HttpVersion::Http2)
+    ///     .await
+    /// {
+    ///     Ok(ws) => ws,
+    ///     // The peer answered, but not with a WebSocket. Nothing on this connection is
+    ///     // salvageable, and ALPN has already committed it to HTTP/2, so the retry has
+    ///     // to dial again.
+    ///     Err(err) if err.is_handshake_error() => {
+    ///         WebSocket::connect(url)
+    ///             .http_version(HttpVersion::Http1)
+    ///             .await?
+    ///     }
+    ///     Err(err) => return Err(err),
+    /// };
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// Written out this way the cost is visible: against a peer without RFC 8441, which
+    /// is most of them, every connection pays a full TCP and TLS handshake before the
+    /// one that works. Worth it when the peer is genuinely unknown, not when it is not.
     Http2,
 }
 

--- a/src/native/builder.rs
+++ b/src/native/builder.rs
@@ -64,9 +64,17 @@ pub type HttpRequestBuilder = hyper::http::request::Builder;
 ///     todo!()
 /// }
 /// ```
-pub struct WebSocketBuilder {
+/// The `S` parameter is the stream the finished connection runs on, and it defaults to
+/// the plain or TLS socket that [`WebSocket::connect`] produces, so `WebSocketBuilder`
+/// keeps meaning what it always did.
+///
+/// Only [`http_version`](Self::http_version) changes it, to
+/// [`HttpStream`](super::HttpStream): an HTTP/2 WebSocket lives on one stream of a
+/// multiplexed connection, so there is no socket to hand back. The builder methods are
+/// shared, and only the `Future` impls differ.
+pub struct WebSocketBuilder<S = MaybeTlsStream<TcpStream>> {
     pub(super) opts: Option<WsBuilderOpts>,
-    pub(super) future: Option<BoxFuture<'static, Result<WebSocket<MaybeTlsStream<TcpStream>>>>>,
+    pub(super) future: Option<BoxFuture<'static, Result<WebSocket<S>>>>,
 }
 
 /// Internal options structure for WebSocketBuilder.
@@ -79,9 +87,11 @@ pub(super) struct WsBuilderOpts {
     pub(super) connector: Option<TlsConnector>,
     pub(super) establish_options: Option<Options>,
     pub(super) http_builder: Option<HttpRequestBuilder>,
+    #[cfg(feature = "http2")]
+    pub(super) version: HttpVersion,
 }
 
-impl WebSocketBuilder {
+impl<S> WebSocketBuilder<S> {
     /// Creates a new WebSocketBuilder with the specified URL.
     ///
     /// Initializes a builder with default settings that can be customized
@@ -97,6 +107,8 @@ impl WebSocketBuilder {
                 connector: None,
                 establish_options: None,
                 http_builder: None,
+                #[cfg(feature = "http2")]
+                version: HttpVersion::Http1,
             }),
             future: None,
         }
@@ -193,7 +205,10 @@ impl WebSocketBuilder {
         opts.http_builder = Some(builder);
         self
     }
+}
 
+#[cfg(feature = "http2")]
+impl WebSocketBuilder {
     /// Selects the HTTP version used for the handshake.
     ///
     /// Reaching for this switches the connection to the RFC 8441 machinery and changes
@@ -204,6 +219,8 @@ impl WebSocketBuilder {
     /// Leaving this alone keeps the HTTP/1.1 handshake and the existing return type,
     /// which is what almost every peer wants: RFC 8441 support is rare enough that
     /// HTTP/2 is worth asking for only when the server is known to implement it.
+    ///
+    /// Every other builder method is available before or after this call.
     ///
     /// # Example
     ///
@@ -217,15 +234,15 @@ impl WebSocketBuilder {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(feature = "http2")]
     #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-    pub fn http_version(mut self, version: HttpVersion) -> Http2WebSocketBuilder {
-        let Some(opts) = self.opts.take() else {
+    pub fn http_version(mut self, version: HttpVersion) -> WebSocketBuilder<super::HttpStream> {
+        let Some(mut opts) = self.opts.take() else {
             unreachable!()
         };
-        Http2WebSocketBuilder {
+        opts.version = version;
+
+        WebSocketBuilder {
             opts: Some(opts),
-            version,
             future: None,
         }
     }
@@ -259,65 +276,15 @@ pub enum HttpVersion {
     Http2,
 }
 
-/// Builder for a WebSocket connection with an explicit HTTP version.
-///
-/// Returned by [`WebSocketBuilder::http_version`]. Resolves to an
-/// [`HttpWebSocket`](super::HttpWebSocket) regardless of which version is used, so the
-/// same code path works whether the handshake ends up on HTTP/1.1 or HTTP/2.
 #[cfg(feature = "http2")]
-#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
-pub struct Http2WebSocketBuilder {
-    pub(super) opts: Option<WsBuilderOpts>,
-    pub(super) version: HttpVersion,
-    pub(super) future: Option<BoxFuture<'static, Result<super::HttpWebSocket>>>,
-}
-
-#[cfg(feature = "http2")]
-impl Http2WebSocketBuilder {
-    /// Sets a custom TLS connector.
-    ///
-    /// The connector's ALPN protocols are used as given, so a custom connector must
-    /// offer `h2` for [`HttpVersion::Http2`] to work.
-    pub fn with_connector(mut self, connector: TlsConnector) -> Self {
-        let Some(opts) = &mut self.opts else {
-            unreachable!()
-        };
-        opts.connector = Some(connector);
-        self
-    }
-
-    /// Sets a custom TCP address to connect to, bypassing hostname resolution.
-    pub fn with_tcp_address(mut self, address: SocketAddr) -> Self {
-        let Some(opts) = &mut self.opts else {
-            unreachable!()
-        };
-        opts.tcp_address = Some(address);
-        self
-    }
-
-    /// Sets WebSocket connection options.
-    pub fn with_options(mut self, options: Options) -> Self {
-        let Some(opts) = &mut self.opts else {
-            unreachable!()
-        };
-        opts.establish_options = Some(options);
-        self
-    }
-
-    /// Sets a custom HTTP request builder for the handshake.
-    pub fn with_request(mut self, builder: HttpRequestBuilder) -> Self {
-        let Some(opts) = &mut self.opts else {
-            unreachable!()
-        };
-        opts.http_builder = Some(builder);
-        self
-    }
-}
-
-#[cfg(feature = "http2")]
-impl Future for Http2WebSocketBuilder {
+impl Future for WebSocketBuilder<super::HttpStream> {
     type Output = Result<super::HttpWebSocket>;
 
+    /// Polls the future to establish the WebSocket connection.
+    ///
+    /// Mirrors the default builder's poll, but resolves to an
+    /// [`HttpWebSocket`](super::HttpWebSocket): the HTTP/2 handshake hands back a stream
+    /// of a multiplexed connection rather than the socket underneath it.
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         if let Some(opts) = this.opts.take() {
@@ -327,7 +294,7 @@ impl Future for Http2WebSocketBuilder {
                 opts.connector,
                 opts.establish_options.unwrap_or_default(),
                 opts.http_builder.unwrap_or_else(HttpRequest::builder),
-                this.version,
+                opts.version,
             );
             this.future = Some(Box::pin(future));
         }

--- a/src/native/builder.rs
+++ b/src/native/builder.rs
@@ -201,7 +201,9 @@ impl WebSocketBuilder {
     /// [`TcpWebSocket`](super::TcpWebSocket). An HTTP/2 WebSocket lives on one stream of
     /// a multiplexed connection, so there is no underlying socket to hand back.
     ///
-    /// Leaving this alone keeps the HTTP/1.1 handshake and the existing return type.
+    /// Leaving this alone keeps the HTTP/1.1 handshake and the existing return type,
+    /// which is what almost every peer wants: RFC 8441 support is rare enough that
+    /// HTTP/2 is worth asking for only when the server is known to implement it.
     ///
     /// # Example
     ///
@@ -210,7 +212,7 @@ impl WebSocketBuilder {
     ///
     /// # async fn example() -> yawc::Result<()> {
     /// let ws = WebSocket::connect("wss://example.com/chat".parse()?)
-    ///     .http_version(HttpVersion::Auto)
+    ///     .http_version(HttpVersion::Http2)
     ///     .await?;
     /// # Ok(())
     /// # }
@@ -242,32 +244,19 @@ pub enum HttpVersion {
     #[default]
     Http1,
 
-    /// Always use the HTTP/2 extended CONNECT handshake.
+    /// Use the HTTP/2 extended CONNECT handshake.
     ///
     /// Over `wss://` this offers only the `h2` ALPN protocol, so a server that cannot
     /// speak HTTP/2 fails the TLS handshake rather than silently falling back. Over
     /// `ws://` it assumes HTTP/2 prior knowledge, which only works against a server
     /// configured to expect it.
+    ///
+    /// This is an explicit choice because RFC 8441 support is rare: negotiating `h2` only
+    /// means the peer speaks HTTP/2, and most deployments serve `h2` for ordinary
+    /// requests while accepting WebSockets over HTTP/1.1 only. Against such a peer this
+    /// fails rather than downgrading, so use it when the server is known to implement
+    /// RFC 8441. Everything else should stay on the default HTTP/1.1 handshake.
     Http2,
-
-    /// Use HTTP/2 where it actually works, otherwise HTTP/1.1.
-    ///
-    /// Over `wss://` this offers `h2` and `http/1.1` over ALPN. If the server picks `h2`
-    /// but then refuses the extended CONNECT, the connection is retried over HTTP/1.1 on
-    /// a fresh connection, because ALPN has already committed the first one to HTTP/2.
-    ///
-    /// That retry is not a corner case. Negotiating `h2` only says the peer speaks
-    /// HTTP/2, not that it implements RFC 8441, and most deployments serve `h2` for
-    /// ordinary requests while accepting WebSockets over HTTP/1.1 only, so the fallback
-    /// is the common path rather than the exception.
-    ///
-    /// Over `ws://` there is nothing to negotiate with, so this is HTTP/1.1. Prior
-    /// knowledge is not assumed, since it would break an ordinary HTTP/1.1 server.
-    ///
-    /// The cost of the fallback is one extra connection attempt against servers that do
-    /// not support RFC 8441. Use [`HttpVersion::Http1`] to avoid it when the peer is
-    /// known not to, or [`HttpVersion::Http2`] to fail loudly when it should.
-    Auto,
 }
 
 /// Builder for a WebSocket connection with an explicit HTTP version.

--- a/src/native/builder.rs
+++ b/src/native/builder.rs
@@ -193,6 +193,148 @@ impl WebSocketBuilder {
         opts.http_builder = Some(builder);
         self
     }
+
+    /// Selects the HTTP version used for the handshake.
+    ///
+    /// Reaching for this switches the connection to the RFC 8441 machinery and changes
+    /// what the builder resolves to: [`HttpWebSocket`](super::HttpWebSocket) instead of
+    /// [`TcpWebSocket`](super::TcpWebSocket). An HTTP/2 WebSocket lives on one stream of
+    /// a multiplexed connection, so there is no underlying socket to hand back.
+    ///
+    /// Leaving this alone keeps the HTTP/1.1 handshake and the existing return type.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use yawc::{HttpVersion, WebSocket};
+    ///
+    /// # async fn example() -> yawc::Result<()> {
+    /// let ws = WebSocket::connect("wss://example.com/chat".parse()?)
+    ///     .http_version(HttpVersion::Auto)
+    ///     .await?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[cfg(feature = "http2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+    pub fn http_version(mut self, version: HttpVersion) -> Http2WebSocketBuilder {
+        let Some(opts) = self.opts.take() else {
+            unreachable!()
+        };
+        Http2WebSocketBuilder {
+            opts: Some(opts),
+            version,
+            future: None,
+        }
+    }
+}
+
+/// The HTTP version used to carry a WebSocket connection.
+///
+/// HTTP/1.1 uses the RFC 6455 `Upgrade` handshake. HTTP/2 uses the RFC 8441 extended
+/// CONNECT handshake, which puts the connection on a single stream of a multiplexed
+/// HTTP/2 connection.
+#[cfg(feature = "http2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum HttpVersion {
+    /// Always use the HTTP/1.1 `Upgrade` handshake.
+    #[default]
+    Http1,
+
+    /// Always use the HTTP/2 extended CONNECT handshake.
+    ///
+    /// Over `wss://` this offers only the `h2` ALPN protocol, so a server that cannot
+    /// speak HTTP/2 fails the TLS handshake rather than silently falling back. Over
+    /// `ws://` it assumes HTTP/2 prior knowledge, which only works against a server
+    /// configured to expect it.
+    Http2,
+
+    /// Let ALPN decide, preferring HTTP/2.
+    ///
+    /// Over `wss://` this offers `h2` and `http/1.1` and follows whatever the server
+    /// picks. Over `ws://` there is nothing to negotiate with, so this is HTTP/1.1.
+    Auto,
+}
+
+/// Builder for a WebSocket connection with an explicit HTTP version.
+///
+/// Returned by [`WebSocketBuilder::http_version`]. Resolves to an
+/// [`HttpWebSocket`](super::HttpWebSocket) regardless of which version is used, so the
+/// same code path works whether the handshake ends up on HTTP/1.1 or HTTP/2.
+#[cfg(feature = "http2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "http2")))]
+pub struct Http2WebSocketBuilder {
+    pub(super) opts: Option<WsBuilderOpts>,
+    pub(super) version: HttpVersion,
+    pub(super) future: Option<BoxFuture<'static, Result<super::HttpWebSocket>>>,
+}
+
+#[cfg(feature = "http2")]
+impl Http2WebSocketBuilder {
+    /// Sets a custom TLS connector.
+    ///
+    /// The connector's ALPN protocols are used as given, so a custom connector must
+    /// offer `h2` for [`HttpVersion::Http2`] to work.
+    pub fn with_connector(mut self, connector: TlsConnector) -> Self {
+        let Some(opts) = &mut self.opts else {
+            unreachable!()
+        };
+        opts.connector = Some(connector);
+        self
+    }
+
+    /// Sets a custom TCP address to connect to, bypassing hostname resolution.
+    pub fn with_tcp_address(mut self, address: SocketAddr) -> Self {
+        let Some(opts) = &mut self.opts else {
+            unreachable!()
+        };
+        opts.tcp_address = Some(address);
+        self
+    }
+
+    /// Sets WebSocket connection options.
+    pub fn with_options(mut self, options: Options) -> Self {
+        let Some(opts) = &mut self.opts else {
+            unreachable!()
+        };
+        opts.establish_options = Some(options);
+        self
+    }
+
+    /// Sets a custom HTTP request builder for the handshake.
+    pub fn with_request(mut self, builder: HttpRequestBuilder) -> Self {
+        let Some(opts) = &mut self.opts else {
+            unreachable!()
+        };
+        opts.http_builder = Some(builder);
+        self
+    }
+}
+
+#[cfg(feature = "http2")]
+impl Future for Http2WebSocketBuilder {
+    type Output = Result<super::HttpWebSocket>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        if let Some(opts) = this.opts.take() {
+            let future = super::connect_versioned(
+                opts.url,
+                opts.tcp_address,
+                opts.connector,
+                opts.establish_options.unwrap_or_default(),
+                opts.http_builder.unwrap_or_else(HttpRequest::builder),
+                this.version,
+            );
+            this.future = Some(Box::pin(future));
+        }
+
+        let Some(pinned) = &mut this.future else {
+            unreachable!()
+        };
+        pinned.poll_unpin(cx)
+    }
 }
 
 impl Future for WebSocketBuilder {

--- a/src/native/http2.rs
+++ b/src/native/http2.rs
@@ -23,8 +23,6 @@
 //!
 //! [`enable_connect_protocol`]: https://docs.rs/hyper/latest/hyper/server/conn/http2/struct.Builder.html#method.enable_connect_protocol
 
-use std::str::FromStr;
-
 use bytes::Bytes;
 use http_body_util::Empty;
 use hyper::{
@@ -127,12 +125,7 @@ pub(super) fn verify<B>(response: &Response<B>, options: Options) -> Result<Nego
         ));
     }
 
-    let extensions = response
-        .headers()
-        .get(header::SEC_WEBSOCKET_EXTENSIONS)
-        .and_then(|h| h.to_str().ok())
-        .map(WebSocketExtensions::from_str)
-        .and_then(std::result::Result::ok);
+    let extensions = WebSocketExtensions::from_headers(response.headers());
 
     Negotiation::new(extensions, &options, Role::Client)
 }
@@ -162,7 +155,7 @@ where
     let (mut sender, conn) =
         hyper::client::conn::http2::handshake(TokioExecutor::new(), TokioIo::new(io)).await?;
 
-    tokio::spawn(async move {
+    super::spawn_connection(async move {
         if let Err(err) = conn.await {
             log::debug!("http2 connection closed: {err:?}");
         }
@@ -227,29 +220,21 @@ pub(super) fn upgrade<B>(request: &mut Request<B>, options: Options) -> UpgradeR
         return Err(WebSocketError::InvalidSecWebsocketVersion);
     }
 
-    let client_extensions = request
-        .headers()
-        .get(header::SEC_WEBSOCKET_EXTENSIONS)
-        .and_then(|h| h.to_str().ok())
-        .map(WebSocketExtensions::from_str)
-        .and_then(std::result::Result::ok);
+    let client_extensions = WebSocketExtensions::from_headers(request.headers());
 
     let mut response = Response::builder()
         .status(StatusCode::OK)
         .body(Empty::new())
         .expect("bug: failed to build response");
 
-    let extensions = match (client_extensions, options.compression.as_ref()) {
-        (Some(client_offer), Some(server_offer)) => {
-            let offer = server_offer.merge(&client_offer);
-            let header_value = offer.to_string().parse().expect("extensions header");
-            response
-                .headers_mut()
-                .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
-            Some(offer)
-        }
-        _ => None,
-    };
+    let extensions = WebSocketExtensions::agree(options.compression.as_ref(), client_extensions);
+
+    if let Some(offer) = extensions.as_ref() {
+        let header_value = offer.to_string().parse().expect("extensions header");
+        response
+            .headers_mut()
+            .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
+    }
 
     let fut = UpgradeFut {
         inner: hyper::upgrade::on(request),

--- a/src/native/http2.rs
+++ b/src/native/http2.rs
@@ -33,10 +33,7 @@ use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::io::{AsyncRead, AsyncWrite};
 use url::Url;
 
-use super::{
-    HttpRequestBuilder, HttpStream, HttpWebSocket, Negotiation, Options, Role, UpgradeFut,
-    UpgradeResult,
-};
+use super::{HttpRequestBuilder, HttpStream, HttpWebSocket, Negotiation, Options, Role};
 use crate::{compression::WebSocketExtensions, Result, WebSocketError};
 
 /// The value of the `:protocol` pseudo-header identifying a WebSocket stream.
@@ -199,51 +196,6 @@ fn connect_error(err: hyper::Error) -> WebSocketError {
     WebSocketError::from(err)
 }
 
-/// Accepts an RFC 8441 extended CONNECT request and produces the handshake response.
-///
-/// Called by [`WebSocket::upgrade_with_options`] when the request is an extended CONNECT,
-/// so server code does not normally reach for this directly.
-///
-/// [`WebSocket::upgrade_with_options`]: super::WebSocket::upgrade_with_options
-pub(super) fn upgrade<B>(request: &mut Request<B>, options: Options) -> UpgradeResult {
-    if !is_extended_connect(request) {
-        return Err(WebSocketError::MissingConnectProtocol);
-    }
-
-    // RFC 8441 keeps the version negotiation but drops the key exchange.
-    if request
-        .headers()
-        .get(header::SEC_WEBSOCKET_VERSION)
-        .map(|v| v.as_bytes())
-        != Some(b"13")
-    {
-        return Err(WebSocketError::InvalidSecWebsocketVersion);
-    }
-
-    let client_extensions = WebSocketExtensions::from_headers(request.headers());
-
-    let mut response = Response::builder()
-        .status(StatusCode::OK)
-        .body(Empty::new())
-        .expect("bug: failed to build response");
-
-    let extensions = WebSocketExtensions::agree(options.compression.as_ref(), client_extensions);
-
-    if let Some(offer) = extensions.as_ref() {
-        let header_value = offer.to_string().parse().expect("extensions header");
-        response
-            .headers_mut()
-            .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
-    }
-
-    let fut = UpgradeFut {
-        inner: hyper::upgrade::on(request),
-        negotiation: Some(Negotiation::new(extensions, &options, Role::Server)?),
-    };
-
-    Ok((response, fut))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -396,7 +348,7 @@ mod tests {
         req.extensions_mut()
             .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
 
-        let err = upgrade(&mut req, Options::default()).unwrap_err();
+        let err = crate::WebSocket::upgrade_with_options(&mut req, Options::default()).unwrap_err();
         assert!(matches!(err, WebSocketError::InvalidSecWebsocketVersion));
     }
 
@@ -411,7 +363,8 @@ mod tests {
         req.extensions_mut()
             .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
 
-        let (response, _fut) = upgrade(&mut req, Options::default()).unwrap();
+        let (response, _fut) =
+            crate::WebSocket::upgrade_with_options(&mut req, Options::default()).unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
         assert!(response
@@ -434,8 +387,11 @@ mod tests {
         req.extensions_mut()
             .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
 
-        let (response, _fut) =
-            upgrade(&mut req, Options::default().with_balanced_compression()).unwrap();
+        let (response, _fut) = crate::WebSocket::upgrade_with_options(
+            &mut req,
+            Options::default().with_balanced_compression(),
+        )
+        .unwrap();
 
         let agreed = response
             .headers()

--- a/src/native/http2.rs
+++ b/src/native/http2.rs
@@ -27,7 +27,10 @@ use std::str::FromStr;
 
 use bytes::Bytes;
 use http_body_util::Empty;
-use hyper::{ext::Protocol, header, http::Extensions, Method, Request, Response, StatusCode};
+use hyper::{
+    ext::Protocol, header, header::HeaderValue, http::Extensions, Method, Request, Response,
+    StatusCode,
+};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::io::{AsyncRead, AsyncWrite};
 use url::Url;
@@ -83,14 +86,20 @@ pub(super) fn build_request(
     let path = &url[url::Position::BeforePath..];
     let uri = format!("{scheme}://{authority}{path}");
 
-    // RFC 8441 section 5: no Sec-WebSocket-Key, no Upgrade, no Connection. The version
-    // header stays, so a server can still reject a version it does not speak.
+    // RFC 8441 section 5: no Sec-WebSocket-Key, no Upgrade, no Connection.
     let mut request = builder
         .method(Method::CONNECT)
         .uri(uri)
-        .header(header::SEC_WEBSOCKET_VERSION, "13")
         .body(Empty::<Bytes>::new())
         .expect("request build");
+
+    // Inserted rather than appended: 13 is the only version this speaks, and a caller
+    // that set the header on `builder` would otherwise leave the request carrying two
+    // conflicting values.
+    request.headers_mut().insert(
+        header::SEC_WEBSOCKET_VERSION,
+        HeaderValue::from_static("13"),
+    );
 
     request
         .extensions_mut()
@@ -292,6 +301,38 @@ mod tests {
 
         assert_eq!(req.uri().scheme_str(), Some("http"));
         assert_eq!(req.uri().authority().unwrap().as_str(), "example.com:8080");
+    }
+
+    #[test]
+    fn caller_cannot_override_the_websocket_version() {
+        // A caller-supplied version must be replaced, not appended, or the request goes
+        // out with two conflicting values and the server picks whichever it reads first.
+        let req = build_request(
+            &"wss://example.com/chat".parse().unwrap(),
+            &Options::default(),
+            hyper::Request::builder().header(header::SEC_WEBSOCKET_VERSION, "8"),
+        )
+        .unwrap();
+
+        let versions: Vec<_> = req
+            .headers()
+            .get_all(header::SEC_WEBSOCKET_VERSION)
+            .iter()
+            .collect();
+
+        assert_eq!(versions, vec!["13"]);
+    }
+
+    #[test]
+    fn caller_headers_are_preserved() {
+        let req = build_request(
+            &"wss://example.com/chat".parse().unwrap(),
+            &Options::default(),
+            hyper::Request::builder().header("authorization", "Bearer token"),
+        )
+        .unwrap();
+
+        assert_eq!(req.headers().get("authorization").unwrap(), "Bearer token");
     }
 
     #[test]

--- a/src/native/http2.rs
+++ b/src/native/http2.rs
@@ -1,0 +1,422 @@
+//! WebSockets over HTTP/2 (RFC 8441).
+//!
+//! RFC 8441 carries WebSocket connections over a single HTTP/2 stream opened with an
+//! extended CONNECT request. Only the handshake changes: once the stream is established
+//! the frames are the same RFC 6455 frames, masking included, and `permessage-deflate`
+//! still applies because HPACK compresses headers rather than payloads.
+//!
+//! # Differences from the HTTP/1.1 handshake
+//!
+//! The request uses `:method = CONNECT` with `:protocol = websocket` instead of a `GET`
+//! with `Upgrade`. `Sec-WebSocket-Key`, `Upgrade` and `Connection` are not sent: RFC 8441
+//! section 5 forbids them, since HTTP/2 stream framing replaces what the key was
+//! guarding. A successful handshake answers `200`, not `101`, and there is no
+//! `Sec-WebSocket-Accept` to check.
+//!
+//! # Server support
+//!
+//! A server can only accept extended CONNECT if it advertises
+//! `SETTINGS_ENABLE_CONNECT_PROTOCOL`. With hyper that means calling
+//! [`enable_connect_protocol`] on the HTTP/2 server builder. Without it, hyper never
+//! surfaces the request and the peer resets the stream, which shows up on the client as
+//! [`WebSocketError::ExtendedConnectNotSupported`].
+//!
+//! [`enable_connect_protocol`]: https://docs.rs/hyper/latest/hyper/server/conn/http2/struct.Builder.html#method.enable_connect_protocol
+
+use std::str::FromStr;
+
+use bytes::Bytes;
+use http_body_util::Empty;
+use hyper::{ext::Protocol, header, http::Extensions, Method, Request, Response, StatusCode};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::io::{AsyncRead, AsyncWrite};
+use url::Url;
+
+use super::{
+    HttpRequestBuilder, HttpStream, HttpWebSocket, Negotiation, Options, Role, UpgradeFut,
+    UpgradeResult,
+};
+use crate::{compression::WebSocketExtensions, Result, WebSocketError};
+
+/// The value of the `:protocol` pseudo-header identifying a WebSocket stream.
+pub(super) const WEBSOCKET_PROTOCOL: &str = "websocket";
+
+/// Returns whether a request is an RFC 8441 extended CONNECT for WebSockets.
+///
+/// Used to pick between the HTTP/1.1 and HTTP/2 handshake paths on the server. A plain
+/// `CONNECT` without the `websocket` protocol is a tunnel request, not a WebSocket one,
+/// and is not matched here.
+pub(super) fn is_extended_connect<B>(request: &Request<B>) -> bool {
+    is_websocket_connect(request.method(), request.extensions())
+}
+
+/// Same check as [`is_extended_connect`], against a request's parts.
+pub(super) fn is_websocket_connect(method: &Method, extensions: &Extensions) -> bool {
+    method == Method::CONNECT
+        && extensions
+            .get::<Protocol>()
+            .is_some_and(|protocol| protocol.as_str() == WEBSOCKET_PROTOCOL)
+}
+
+/// Builds the extended CONNECT request for a WebSocket handshake over HTTP/2.
+///
+/// `builder` carries any caller-supplied headers. The URL supplies the authority and
+/// path; the scheme is mapped from `ws`/`wss` to `http`/`https` as RFC 8441 requires.
+pub(super) fn build_request(
+    url: &Url,
+    options: &Options,
+    builder: HttpRequestBuilder,
+) -> Result<Request<Empty<Bytes>>> {
+    let scheme = match url.scheme() {
+        "ws" | "http" => "http",
+        "wss" | "https" => "https",
+        _ => return Err(WebSocketError::InvalidHttpScheme),
+    };
+
+    let host = url.host().expect("hostname").to_string();
+    let authority = if let Some(port) = url.port() {
+        format!("{host}:{port}")
+    } else {
+        host
+    };
+
+    let path = &url[url::Position::BeforePath..];
+    let uri = format!("{scheme}://{authority}{path}");
+
+    // RFC 8441 section 5: no Sec-WebSocket-Key, no Upgrade, no Connection. The version
+    // header stays, so a server can still reject a version it does not speak.
+    let mut request = builder
+        .method(Method::CONNECT)
+        .uri(uri)
+        .header(header::SEC_WEBSOCKET_VERSION, "13")
+        .body(Empty::<Bytes>::new())
+        .expect("request build");
+
+    request
+        .extensions_mut()
+        .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
+
+    if let Some(compression) = options.compression.as_ref() {
+        let extensions = WebSocketExtensions::from(compression);
+        let header_value = extensions.to_string().parse().expect("extensions header");
+        request
+            .headers_mut()
+            .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
+    }
+
+    Ok(request)
+}
+
+/// Checks the response to an extended CONNECT and resolves the negotiated settings.
+///
+/// Unlike the HTTP/1.1 handshake this accepts `200` and has no `Sec-WebSocket-Accept`,
+/// `Upgrade` or `Connection` headers to validate.
+pub(super) fn verify<B>(response: &Response<B>, options: Options) -> Result<Negotiation> {
+    if response.status() != StatusCode::OK {
+        return Err(WebSocketError::InvalidStatusCode(
+            response.status().as_u16(),
+        ));
+    }
+
+    let extensions = response
+        .headers()
+        .get(header::SEC_WEBSOCKET_EXTENSIONS)
+        .and_then(|h| h.to_str().ok())
+        .map(WebSocketExtensions::from_str)
+        .and_then(std::result::Result::ok);
+
+    Negotiation::new(extensions, &options, Role::Client)
+}
+
+/// Performs an RFC 8441 handshake over an established HTTP/2-capable connection.
+///
+/// `io` must be a stream the peer will speak HTTP/2 on: either a TLS stream that
+/// negotiated the `h2` ALPN protocol, or a plaintext stream where HTTP/2 prior knowledge
+/// applies. Prefer [`WebSocket::connect`] with
+/// [`http_version`](super::WebSocketBuilder::http_version), which sets ALPN up for you.
+///
+/// The HTTP/2 connection is driven by a spawned task and is closed once the returned
+/// WebSocket is dropped.
+///
+/// [`WebSocket::connect`]: super::WebSocket::connect
+pub async fn handshake<S>(
+    url: Url,
+    io: S,
+    options: Options,
+    builder: HttpRequestBuilder,
+) -> Result<HttpWebSocket>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    let request = build_request(&url, &options, builder)?;
+
+    let (mut sender, conn) =
+        hyper::client::conn::http2::handshake(TokioExecutor::new(), TokioIo::new(io)).await?;
+
+    tokio::spawn(async move {
+        if let Err(err) = conn.await {
+            log::debug!("http2 connection closed: {err:?}");
+        }
+    });
+
+    let mut response = sender.send_request(request).await.map_err(connect_error)?;
+    let negotiated = verify(&response, options)?;
+
+    let upgraded = hyper::upgrade::on(&mut response)
+        .await
+        .map_err(connect_error)?;
+
+    Ok(HttpWebSocket::new(
+        Role::Client,
+        HttpStream::from(TokioIo::new(upgraded)),
+        Bytes::new(),
+        negotiated,
+    ))
+}
+
+/// Maps a failed extended CONNECT to a diagnosable error.
+///
+/// hyper does not expose the peer's settings to the client, so there is no way to check
+/// `SETTINGS_ENABLE_CONNECT_PROTOCOL` up front. A server without it treats the
+/// `:protocol` pseudo-header as malformed and resets the stream with `PROTOCOL_ERROR`,
+/// which is specific enough to report as a missing RFC 8441 implementation rather than
+/// an opaque HTTP/2 failure.
+fn connect_error(err: hyper::Error) -> WebSocketError {
+    use std::error::Error;
+
+    let mut source: Option<&(dyn Error + 'static)> = Some(&err);
+    while let Some(cause) = source {
+        if let Some(h2_err) = cause.downcast_ref::<h2::Error>() {
+            if h2_err.reason() == Some(h2::Reason::PROTOCOL_ERROR) {
+                return WebSocketError::ExtendedConnectNotSupported;
+            }
+        }
+        source = cause.source();
+    }
+
+    WebSocketError::from(err)
+}
+
+/// Accepts an RFC 8441 extended CONNECT request and produces the handshake response.
+///
+/// Called by [`WebSocket::upgrade_with_options`] when the request is an extended CONNECT,
+/// so server code does not normally reach for this directly.
+///
+/// [`WebSocket::upgrade_with_options`]: super::WebSocket::upgrade_with_options
+pub(super) fn upgrade<B>(request: &mut Request<B>, options: Options) -> UpgradeResult {
+    if !is_extended_connect(request) {
+        return Err(WebSocketError::MissingConnectProtocol);
+    }
+
+    // RFC 8441 keeps the version negotiation but drops the key exchange.
+    if request
+        .headers()
+        .get(header::SEC_WEBSOCKET_VERSION)
+        .map(|v| v.as_bytes())
+        != Some(b"13")
+    {
+        return Err(WebSocketError::InvalidSecWebsocketVersion);
+    }
+
+    let client_extensions = request
+        .headers()
+        .get(header::SEC_WEBSOCKET_EXTENSIONS)
+        .and_then(|h| h.to_str().ok())
+        .map(WebSocketExtensions::from_str)
+        .and_then(std::result::Result::ok);
+
+    let mut response = Response::builder()
+        .status(StatusCode::OK)
+        .body(Empty::new())
+        .expect("bug: failed to build response");
+
+    let extensions = match (client_extensions, options.compression.as_ref()) {
+        (Some(client_offer), Some(server_offer)) => {
+            let offer = server_offer.merge(&client_offer);
+            let header_value = offer.to_string().parse().expect("extensions header");
+            response
+                .headers_mut()
+                .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
+            Some(offer)
+        }
+        _ => None,
+    };
+
+    let fut = UpgradeFut {
+        inner: hyper::upgrade::on(request),
+        negotiation: Some(Negotiation::new(extensions, &options, Role::Server)?),
+    };
+
+    Ok((response, fut))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request(url: &str, options: Options) -> Request<Empty<Bytes>> {
+        build_request(&url.parse().unwrap(), &options, hyper::Request::builder()).unwrap()
+    }
+
+    #[test]
+    fn request_uses_extended_connect() {
+        let req = request("wss://example.com/chat", Options::default());
+
+        assert_eq!(req.method(), Method::CONNECT);
+        assert_eq!(
+            req.extensions().get::<Protocol>().map(Protocol::as_str),
+            Some(WEBSOCKET_PROTOCOL)
+        );
+        assert_eq!(req.uri().scheme_str(), Some("https"));
+        assert_eq!(req.uri().authority().unwrap().as_str(), "example.com");
+        assert_eq!(req.uri().path(), "/chat");
+        assert_eq!(
+            req.headers().get(header::SEC_WEBSOCKET_VERSION).unwrap(),
+            "13"
+        );
+    }
+
+    #[test]
+    fn request_omits_http1_handshake_headers() {
+        let req = request("wss://example.com/chat", Options::default());
+
+        // RFC 8441 section 5 forbids all three over HTTP/2.
+        assert!(req.headers().get(header::SEC_WEBSOCKET_KEY).is_none());
+        assert!(req.headers().get(header::UPGRADE).is_none());
+        assert!(req.headers().get(header::CONNECTION).is_none());
+    }
+
+    #[test]
+    fn plaintext_url_maps_to_http_scheme() {
+        let req = request("ws://example.com:8080/chat", Options::default());
+
+        assert_eq!(req.uri().scheme_str(), Some("http"));
+        assert_eq!(req.uri().authority().unwrap().as_str(), "example.com:8080");
+    }
+
+    #[test]
+    fn request_offers_compression_when_enabled() {
+        let req = request(
+            "wss://example.com/chat",
+            Options::default().with_balanced_compression(),
+        );
+
+        let offer = req
+            .headers()
+            .get(header::SEC_WEBSOCKET_EXTENSIONS)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(offer.contains("permessage-deflate"));
+    }
+
+    #[test]
+    fn rejects_non_websocket_scheme() {
+        let err = build_request(
+            &"ftp://example.com/chat".parse().unwrap(),
+            &Options::default(),
+            hyper::Request::builder(),
+        )
+        .unwrap_err();
+
+        assert!(matches!(err, WebSocketError::InvalidHttpScheme));
+    }
+
+    #[test]
+    fn verify_accepts_200_not_101() {
+        let ok = Response::builder().status(200).body(()).unwrap();
+        assert!(verify(&ok, Options::default()).is_ok());
+
+        let switching = Response::builder().status(101).body(()).unwrap();
+        let err = verify(&switching, Options::default()).unwrap_err();
+        assert!(matches!(err, WebSocketError::InvalidStatusCode(101)));
+    }
+
+    #[test]
+    fn is_extended_connect_ignores_plain_connect() {
+        let mut tunnel = Request::builder()
+            .method(Method::CONNECT)
+            .uri("https://example.com/")
+            .body(())
+            .unwrap();
+        assert!(!is_extended_connect(&tunnel));
+
+        tunnel
+            .extensions_mut()
+            .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
+        assert!(is_extended_connect(&tunnel));
+    }
+
+    #[test]
+    fn is_extended_connect_ignores_http1_upgrade() {
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/chat")
+            .header(header::UPGRADE, "websocket")
+            .body(())
+            .unwrap();
+
+        assert!(!is_extended_connect(&req));
+    }
+
+    #[test]
+    fn upgrade_rejects_wrong_version() {
+        let mut req = Request::builder()
+            .method(Method::CONNECT)
+            .uri("https://example.com/chat")
+            .header(header::SEC_WEBSOCKET_VERSION, "8")
+            .body(())
+            .unwrap();
+        req.extensions_mut()
+            .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
+
+        let err = upgrade(&mut req, Options::default()).unwrap_err();
+        assert!(matches!(err, WebSocketError::InvalidSecWebsocketVersion));
+    }
+
+    #[test]
+    fn upgrade_answers_200_without_accept_header() {
+        let mut req = Request::builder()
+            .method(Method::CONNECT)
+            .uri("https://example.com/chat")
+            .header(header::SEC_WEBSOCKET_VERSION, "13")
+            .body(())
+            .unwrap();
+        req.extensions_mut()
+            .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
+
+        let (response, _fut) = upgrade(&mut req, Options::default()).unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(response
+            .headers()
+            .get(header::SEC_WEBSOCKET_ACCEPT)
+            .is_none());
+        assert!(response.headers().get(header::UPGRADE).is_none());
+        assert!(response.headers().get(header::CONNECTION).is_none());
+    }
+
+    #[test]
+    fn upgrade_negotiates_compression() {
+        let mut req = Request::builder()
+            .method(Method::CONNECT)
+            .uri("https://example.com/chat")
+            .header(header::SEC_WEBSOCKET_VERSION, "13")
+            .header(header::SEC_WEBSOCKET_EXTENSIONS, "permessage-deflate")
+            .body(())
+            .unwrap();
+        req.extensions_mut()
+            .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
+
+        let (response, _fut) =
+            upgrade(&mut req, Options::default().with_balanced_compression()).unwrap();
+
+        let agreed = response
+            .headers()
+            .get(header::SEC_WEBSOCKET_EXTENSIONS)
+            .unwrap()
+            .to_str()
+            .unwrap();
+        assert!(agreed.contains("permessage-deflate"));
+    }
+}

--- a/src/native/http2.rs
+++ b/src/native/http2.rs
@@ -44,12 +44,10 @@ pub(super) const WEBSOCKET_PROTOCOL: &str = "websocket";
 /// Used to pick between the HTTP/1.1 and HTTP/2 handshake paths on the server. A plain
 /// `CONNECT` without the `websocket` protocol is a tunnel request, not a WebSocket one,
 /// and is not matched here.
-pub(super) fn is_extended_connect<B>(request: &Request<B>) -> bool {
-    is_websocket_connect(request.method(), request.extensions())
-}
-
-/// Same check as [`is_extended_connect`], against a request's parts.
-pub(super) fn is_websocket_connect(method: &Method, extensions: &Extensions) -> bool {
+///
+/// Takes the method and extensions rather than a whole request, so it serves both the
+/// `Request` the hyper path has and the `Parts` the axum extractor is handed.
+pub(super) fn is_extended_connect(method: &Method, extensions: &Extensions) -> bool {
     method == Method::CONNECT
         && extensions
             .get::<Protocol>()
@@ -317,12 +315,12 @@ mod tests {
             .uri("https://example.com/")
             .body(())
             .unwrap();
-        assert!(!is_extended_connect(&tunnel));
+        assert!(!is_extended_connect(tunnel.method(), tunnel.extensions()));
 
         tunnel
             .extensions_mut()
             .insert(Protocol::from_static(WEBSOCKET_PROTOCOL));
-        assert!(is_extended_connect(&tunnel));
+        assert!(is_extended_connect(tunnel.method(), tunnel.extensions()));
     }
 
     #[test]
@@ -334,7 +332,7 @@ mod tests {
             .body(())
             .unwrap();
 
-        assert!(!is_extended_connect(&req));
+        assert!(!is_extended_connect(req.method(), req.extensions()));
     }
 
     #[test]

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1422,8 +1422,7 @@ fn generate_key() -> String {
 ///
 /// Unlike [`WebSocket::connect_priv`] this always resolves to an [`HttpWebSocket`],
 /// because an HTTP/2 WebSocket is one stream of a multiplexed connection and there is no
-/// socket to hand back. Keeping the return type the same for both versions is what lets
-/// [`HttpVersion::Auto`] decide at runtime.
+/// socket to hand back. Both versions therefore produce the same type.
 #[cfg(feature = "http2")]
 async fn connect_versioned(
     url: Url,
@@ -1433,80 +1432,6 @@ async fn connect_versioned(
     builder: HttpRequestBuilder,
     version: HttpVersion,
 ) -> Result<HttpWebSocket> {
-    // The builder is consumed by whichever handshake runs, but Auto may need to build a
-    // second request after a failed one, so the caller's headers are kept aside.
-    let headers = builder.headers_ref().cloned().unwrap_or_default();
-
-    let (stream, use_http2) = dial(&url, tcp_address, connector.clone(), &options, version).await?;
-
-    if !use_http2 {
-        return handshake_http1_upgraded(url, stream, options, builder).await;
-    }
-
-    let attempt = http2::handshake(
-        url.clone(),
-        stream,
-        options.clone(),
-        builder_with_headers(&headers),
-    )
-    .await;
-
-    match attempt {
-        Ok(ws) => Ok(ws),
-        // ALPN only says the peer speaks HTTP/2, not that it implements RFC 8441, and
-        // most deployments serve h2 for ordinary requests while handling WebSockets over
-        // HTTP/1.1 only. Auto promised to negotiate, so it dials again rather than
-        // failing a connection that HTTP/1.1 would have made. The retry needs a new
-        // connection because ALPN already committed this one to h2.
-        Err(err) if version == HttpVersion::Auto && is_extended_connect_refused(&err) => {
-            log::debug!("extended CONNECT refused ({err}), retrying over http/1.1");
-
-            let (stream, _) =
-                dial(&url, tcp_address, connector, &options, HttpVersion::Http1).await?;
-
-            handshake_http1_upgraded(url, stream, options, builder).await
-        }
-        Err(err) => Err(err),
-    }
-}
-
-/// Whether an error means the peer does not do RFC 8441, as opposed to a connection or
-/// protocol problem that HTTP/1.1 would hit too.
-///
-/// A server that never enabled extended CONNECT either resets the stream or answers with
-/// a client error. Anything else, an I/O failure or a malformed response, is not
-/// something a second attempt would fix.
-#[cfg(feature = "http2")]
-fn is_extended_connect_refused(err: &WebSocketError) -> bool {
-    match err {
-        WebSocketError::ExtendedConnectNotSupported => true,
-        WebSocketError::InvalidStatusCode(code) => (400..500).contains(code),
-        _ => false,
-    }
-}
-
-/// Rebuilds a request builder from a set of caller-supplied headers.
-///
-/// [`HttpRequestBuilder`] cannot be cloned, so a retry has to reconstruct it. Iterating
-/// the map yields one entry per value, and `header` appends, so repeated headers survive.
-#[cfg(feature = "http2")]
-fn builder_with_headers(headers: &hyper::HeaderMap) -> HttpRequestBuilder {
-    headers
-        .iter()
-        .fold(HttpRequest::builder(), |builder, (name, value)| {
-            builder.header(name, value)
-        })
-}
-
-/// Opens a connection and reports whether the HTTP/2 handshake should be used on it.
-#[cfg(feature = "http2")]
-async fn dial(
-    url: &Url,
-    tcp_address: Option<SocketAddr>,
-    connector: Option<TlsConnector>,
-    options: &Options,
-    version: HttpVersion,
-) -> Result<(MaybeTlsStream<TcpStream>, bool)> {
     let host = url.host().expect("hostname").to_string();
 
     let tcp_stream = if let Some(tcp_address) = tcp_address {
@@ -1518,33 +1443,26 @@ async fn dial(
 
     let _ = tcp_stream.set_nodelay(options.no_delay);
 
-    // Over plaintext there is no ALPN to consult, so the version has to be assumed:
-    // HTTP/2 means prior knowledge, anything else means HTTP/1.1. Auto stays on HTTP/1.1
-    // rather than guessing, since prior knowledge would break an ordinary HTTP/1.1 server.
-    match url.scheme() {
-        "ws" => Ok((
-            MaybeTlsStream::Plain(tcp_stream),
-            version == HttpVersion::Http2,
-        )),
+    // Over plaintext there is no ALPN to negotiate with, so HTTP/2 means prior knowledge.
+    let stream = match url.scheme() {
+        "ws" => MaybeTlsStream::Plain(tcp_stream),
         "wss" => {
             let connector = connector.unwrap_or_else(|| tls_connector_with_alpn(alpn_for(version)));
             let domain = ServerName::try_from(host)
                 .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))?;
 
-            let tls_stream = connector.connect(domain, tcp_stream).await?;
-            let negotiated_h2 = tls_stream.get_ref().1.alpn_protocol() == Some(b"h2");
-
-            // A custom connector may not offer h2 at all, so an explicit Http2 request is
-            // honored even when ALPN stayed silent. Auto follows what the server picked.
-            let use_http2 = match version {
-                HttpVersion::Http1 => false,
-                HttpVersion::Http2 => true,
-                HttpVersion::Auto => negotiated_h2,
-            };
-
-            Ok((MaybeTlsStream::Tls(tls_stream), use_http2))
+            MaybeTlsStream::Tls(connector.connect(domain, tcp_stream).await?)
         }
-        _ => Err(WebSocketError::InvalidHttpScheme),
+        _ => return Err(WebSocketError::InvalidHttpScheme),
+    };
+
+    // Whatever the caller asked for is what runs. There is nothing to negotiate: a peer
+    // that speaks h2 usually still wants WebSockets over HTTP/1.1, so picking HTTP/2 on
+    // the strength of ALPN alone would be wrong more often than right. That is why the
+    // HTTP/2 handshake is opt-in and why it fails here rather than quietly downgrading.
+    match version {
+        HttpVersion::Http2 => http2::handshake(url, stream, options, builder).await,
+        HttpVersion::Http1 => handshake_http1_upgraded(url, stream, options, builder).await,
     }
 }
 
@@ -1622,7 +1540,6 @@ fn alpn_for(version: HttpVersion) -> Vec<Vec<u8>> {
     match version {
         HttpVersion::Http1 => vec![b"http/1.1".to_vec()],
         HttpVersion::Http2 => vec![b"h2".to_vec()],
-        HttpVersion::Auto => vec![b"h2".to_vec(), b"http/1.1".to_vec()],
     }
 }
 
@@ -1680,67 +1597,6 @@ mod tests {
 
     use super::*;
     use futures::SinkExt;
-
-    /// Which failures make [`HttpVersion::Auto`] retry over HTTP/1.1.
-    ///
-    /// Retrying costs a whole extra connection, so it has to fire for a peer that simply
-    /// never enabled RFC 8441 and stay out of the way for anything HTTP/1.1 would hit
-    /// too. Against real endpoints both shapes show up: some reset the stream, most
-    /// answer 400.
-    #[cfg(feature = "http2")]
-    #[test]
-    fn auto_retries_only_when_extended_connect_was_refused() {
-        assert!(is_extended_connect_refused(
-            &WebSocketError::ExtendedConnectNotSupported
-        ));
-        assert!(is_extended_connect_refused(
-            &WebSocketError::InvalidStatusCode(400)
-        ));
-        assert!(is_extended_connect_refused(
-            &WebSocketError::InvalidStatusCode(404)
-        ));
-
-        // A server error is the peer failing, not the peer lacking RFC 8441, and a
-        // redirect or success code means the response was simply not what a handshake
-        // looks like. Neither improves by dialing again.
-        assert!(!is_extended_connect_refused(
-            &WebSocketError::InvalidStatusCode(500)
-        ));
-        assert!(!is_extended_connect_refused(
-            &WebSocketError::InvalidStatusCode(301)
-        ));
-
-        // Transport and protocol failures repeat over HTTP/1.1, so retrying only doubles
-        // the wait.
-        assert!(!is_extended_connect_refused(&WebSocketError::IoError(
-            io::Error::new(io::ErrorKind::ConnectionRefused, "nope")
-        )));
-        assert!(!is_extended_connect_refused(
-            &WebSocketError::InvalidHttpScheme
-        ));
-        assert!(!is_extended_connect_refused(
-            &WebSocketError::CompressionNotSupported
-        ));
-    }
-
-    /// The caller's headers have to survive being rebuilt for the retry, including
-    /// repeated ones, or a fallback would quietly drop authentication.
-    #[cfg(feature = "http2")]
-    #[test]
-    fn rebuilt_builder_keeps_every_caller_header() {
-        let mut headers = hyper::HeaderMap::new();
-        headers.insert("authorization", "Bearer token".parse().unwrap());
-        headers.append("cookie", "a=1".parse().unwrap());
-        headers.append("cookie", "b=2".parse().unwrap());
-
-        let rebuilt = builder_with_headers(&headers);
-        let rebuilt = rebuilt.headers_ref().expect("headers");
-
-        assert_eq!(rebuilt.get("authorization").unwrap(), "Bearer token");
-
-        let cookies: Vec<_> = rebuilt.get_all("cookie").iter().collect();
-        assert_eq!(cookies, vec!["a=1", "b=2"]);
-    }
     use std::pin::Pin;
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, DuplexStream, ReadBuf};

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1433,6 +1433,80 @@ async fn connect_versioned(
     builder: HttpRequestBuilder,
     version: HttpVersion,
 ) -> Result<HttpWebSocket> {
+    // The builder is consumed by whichever handshake runs, but Auto may need to build a
+    // second request after a failed one, so the caller's headers are kept aside.
+    let headers = builder.headers_ref().cloned().unwrap_or_default();
+
+    let (stream, use_http2) = dial(&url, tcp_address, connector.clone(), &options, version).await?;
+
+    if !use_http2 {
+        return handshake_http1_upgraded(url, stream, options, builder).await;
+    }
+
+    let attempt = http2::handshake(
+        url.clone(),
+        stream,
+        options.clone(),
+        builder_with_headers(&headers),
+    )
+    .await;
+
+    match attempt {
+        Ok(ws) => Ok(ws),
+        // ALPN only says the peer speaks HTTP/2, not that it implements RFC 8441, and
+        // most deployments serve h2 for ordinary requests while handling WebSockets over
+        // HTTP/1.1 only. Auto promised to negotiate, so it dials again rather than
+        // failing a connection that HTTP/1.1 would have made. The retry needs a new
+        // connection because ALPN already committed this one to h2.
+        Err(err) if version == HttpVersion::Auto && is_extended_connect_refused(&err) => {
+            log::debug!("extended CONNECT refused ({err}), retrying over http/1.1");
+
+            let (stream, _) =
+                dial(&url, tcp_address, connector, &options, HttpVersion::Http1).await?;
+
+            handshake_http1_upgraded(url, stream, options, builder).await
+        }
+        Err(err) => Err(err),
+    }
+}
+
+/// Whether an error means the peer does not do RFC 8441, as opposed to a connection or
+/// protocol problem that HTTP/1.1 would hit too.
+///
+/// A server that never enabled extended CONNECT either resets the stream or answers with
+/// a client error. Anything else, an I/O failure or a malformed response, is not
+/// something a second attempt would fix.
+#[cfg(feature = "http2")]
+fn is_extended_connect_refused(err: &WebSocketError) -> bool {
+    match err {
+        WebSocketError::ExtendedConnectNotSupported => true,
+        WebSocketError::InvalidStatusCode(code) => (400..500).contains(code),
+        _ => false,
+    }
+}
+
+/// Rebuilds a request builder from a set of caller-supplied headers.
+///
+/// [`HttpRequestBuilder`] cannot be cloned, so a retry has to reconstruct it. Iterating
+/// the map yields one entry per value, and `header` appends, so repeated headers survive.
+#[cfg(feature = "http2")]
+fn builder_with_headers(headers: &hyper::HeaderMap) -> HttpRequestBuilder {
+    headers
+        .iter()
+        .fold(HttpRequest::builder(), |builder, (name, value)| {
+            builder.header(name, value)
+        })
+}
+
+/// Opens a connection and reports whether the HTTP/2 handshake should be used on it.
+#[cfg(feature = "http2")]
+async fn dial(
+    url: &Url,
+    tcp_address: Option<SocketAddr>,
+    connector: Option<TlsConnector>,
+    options: &Options,
+    version: HttpVersion,
+) -> Result<(MaybeTlsStream<TcpStream>, bool)> {
     let host = url.host().expect("hostname").to_string();
 
     let tcp_stream = if let Some(tcp_address) = tcp_address {
@@ -1445,12 +1519,13 @@ async fn connect_versioned(
     let _ = tcp_stream.set_nodelay(options.no_delay);
 
     // Over plaintext there is no ALPN to consult, so the version has to be assumed:
-    // HTTP/2 means prior knowledge, anything else means HTTP/1.1.
-    let (stream, use_http2) = match url.scheme() {
-        "ws" => (
+    // HTTP/2 means prior knowledge, anything else means HTTP/1.1. Auto stays on HTTP/1.1
+    // rather than guessing, since prior knowledge would break an ordinary HTTP/1.1 server.
+    match url.scheme() {
+        "ws" => Ok((
             MaybeTlsStream::Plain(tcp_stream),
             version == HttpVersion::Http2,
-        ),
+        )),
         "wss" => {
             let connector = connector.unwrap_or_else(|| tls_connector_with_alpn(alpn_for(version)));
             let domain = ServerName::try_from(host)
@@ -1467,15 +1542,9 @@ async fn connect_versioned(
                 HttpVersion::Auto => negotiated_h2,
             };
 
-            (MaybeTlsStream::Tls(tls_stream), use_http2)
+            Ok((MaybeTlsStream::Tls(tls_stream), use_http2))
         }
-        _ => return Err(WebSocketError::InvalidHttpScheme),
-    };
-
-    if use_http2 {
-        http2::handshake(url, stream, options, builder).await
-    } else {
-        handshake_http1_upgraded(url, stream, options, builder).await
+        _ => Err(WebSocketError::InvalidHttpScheme),
     }
 }
 
@@ -1611,6 +1680,67 @@ mod tests {
 
     use super::*;
     use futures::SinkExt;
+
+    /// Which failures make [`HttpVersion::Auto`] retry over HTTP/1.1.
+    ///
+    /// Retrying costs a whole extra connection, so it has to fire for a peer that simply
+    /// never enabled RFC 8441 and stay out of the way for anything HTTP/1.1 would hit
+    /// too. Against real endpoints both shapes show up: some reset the stream, most
+    /// answer 400.
+    #[cfg(feature = "http2")]
+    #[test]
+    fn auto_retries_only_when_extended_connect_was_refused() {
+        assert!(is_extended_connect_refused(
+            &WebSocketError::ExtendedConnectNotSupported
+        ));
+        assert!(is_extended_connect_refused(
+            &WebSocketError::InvalidStatusCode(400)
+        ));
+        assert!(is_extended_connect_refused(
+            &WebSocketError::InvalidStatusCode(404)
+        ));
+
+        // A server error is the peer failing, not the peer lacking RFC 8441, and a
+        // redirect or success code means the response was simply not what a handshake
+        // looks like. Neither improves by dialing again.
+        assert!(!is_extended_connect_refused(
+            &WebSocketError::InvalidStatusCode(500)
+        ));
+        assert!(!is_extended_connect_refused(
+            &WebSocketError::InvalidStatusCode(301)
+        ));
+
+        // Transport and protocol failures repeat over HTTP/1.1, so retrying only doubles
+        // the wait.
+        assert!(!is_extended_connect_refused(&WebSocketError::IoError(
+            io::Error::new(io::ErrorKind::ConnectionRefused, "nope")
+        )));
+        assert!(!is_extended_connect_refused(
+            &WebSocketError::InvalidHttpScheme
+        ));
+        assert!(!is_extended_connect_refused(
+            &WebSocketError::CompressionNotSupported
+        ));
+    }
+
+    /// The caller's headers have to survive being rebuilt for the retry, including
+    /// repeated ones, or a fallback would quietly drop authentication.
+    #[cfg(feature = "http2")]
+    #[test]
+    fn rebuilt_builder_keeps_every_caller_header() {
+        let mut headers = hyper::HeaderMap::new();
+        headers.insert("authorization", "Bearer token".parse().unwrap());
+        headers.append("cookie", "a=1".parse().unwrap());
+        headers.append("cookie", "b=2".parse().unwrap());
+
+        let rebuilt = builder_with_headers(&headers);
+        let rebuilt = rebuilt.headers_ref().expect("headers");
+
+        assert_eq!(rebuilt.get("authorization").unwrap(), "Bearer token");
+
+        let cookies: Vec<_> = rebuilt.get_all("cookie").iter().collect();
+        assert_eq!(cookies, vec!["a=1", "b=2"]);
+    }
     use std::pin::Pin;
     use std::task::{Context, Poll};
     use tokio::io::{AsyncRead, AsyncWrite, DuplexStream, ReadBuf};

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -114,6 +114,8 @@
 //! - Streaming compression is needed for real-time data
 
 mod builder;
+#[cfg(feature = "http2")]
+pub mod http2;
 mod options;
 mod split;
 pub mod streaming;
@@ -153,6 +155,8 @@ use url::Url;
 
 // Re-exports
 pub use crate::stream::MaybeTlsStream;
+#[cfg(feature = "http2")]
+pub use builder::{Http2WebSocketBuilder, HttpVersion};
 pub use builder::{HttpRequest, HttpRequestBuilder, WebSocketBuilder};
 pub use frame::{Frame, OpCode};
 pub use options::{CompressionLevel, DeflateOptions, Fragmentation, Options};
@@ -1004,11 +1008,23 @@ impl WebSocket<HttpStream> {
     }
 
     /// Attempts to upgrade an incoming `hyper::Request` to a WebSocket connection with customizable options.
+    ///
+    /// Handles both the HTTP/1.1 `Upgrade` handshake and, with the `http2` feature, the
+    /// RFC 8441 extended CONNECT handshake. The protocol is picked from the request, so
+    /// the same handler serves both.
+    ///
+    /// Accepting extended CONNECT also requires calling `enable_connect_protocol()` on
+    /// the hyper HTTP/2 server builder. Without it hyper never delivers the request.
     pub fn upgrade_with_options<B>(
         mut request: impl BorrowMut<Request<B>>,
         options: Options,
     ) -> UpgradeResult {
         let request = request.borrow_mut();
+
+        #[cfg(feature = "http2")]
+        if http2::is_extended_connect(request) {
+            return http2::upgrade(request, options);
+        }
 
         let key = request
             .headers()
@@ -1129,6 +1145,79 @@ where
     /// Asynchronously retrieves the next frame from the WebSocket stream.
     pub async fn next_frame(&mut self) -> Result<Frame> {
         poll_fn(|cx| self.poll_next_frame(cx)).await
+    }
+
+    /// Wraps a stream that has already completed a WebSocket handshake.
+    ///
+    /// Use this when something else performed the handshake and handed back a byte
+    /// stream carrying WebSocket frames: a transport yawc does not implement, a custom
+    /// HTTP client, or a proxy that has already switched protocols.
+    ///
+    /// No handshake is performed and no headers are inspected. The caller is responsible
+    /// for having negotiated a compatible connection. `role` decides whether outgoing
+    /// frames are masked ([`Role::Client`]) or not ([`Role::Server`]); getting it wrong
+    /// produces frames the peer will reject.
+    ///
+    /// If the handshake negotiated `permessage-deflate`, use
+    /// [`WebSocket::from_stream_with_extensions`] instead so the compression context is
+    /// set up with the agreed parameters.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use yawc::{Options, Role, WebSocket};
+    ///
+    /// # async fn example(io: tokio::net::TcpStream) -> yawc::Result<()> {
+    /// // `io` already carries WebSocket frames.
+    /// let ws = WebSocket::from_stream(io, Role::Client, Options::default())?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_stream(io: S, role: Role, options: Options) -> Result<Self> {
+        Self::from_stream_with_extensions(io, role, None, options)
+    }
+
+    /// Wraps an already-handshaked stream, honoring the extensions the peer agreed to.
+    ///
+    /// `extensions` is the raw `Sec-WebSocket-Extensions` header value as agreed by both
+    /// sides, or `None` if no extensions were negotiated. Passing the value the handshake
+    /// settled on matters because permessage-deflate parameters such as
+    /// `server_max_window_bits` must match what the peer is using.
+    ///
+    /// See [`WebSocket::from_stream`] for the general contract.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if `extensions` names permessage-deflate but `options` did not
+    /// enable compression, since there is no way to decode what the peer will send.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use yawc::{Options, Role, WebSocket};
+    ///
+    /// # async fn example(io: tokio::net::TcpStream) -> yawc::Result<()> {
+    /// let ws = WebSocket::from_stream_with_extensions(
+    ///     io,
+    ///     Role::Client,
+    ///     Some("permessage-deflate; client_max_window_bits=15"),
+    ///     Options::default().with_balanced_compression(),
+    /// )?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn from_stream_with_extensions(
+        io: S,
+        role: Role,
+        extensions: Option<&str>,
+        options: Options,
+    ) -> Result<Self> {
+        let extensions = extensions
+            .map(WebSocketExtensions::from_str)
+            .and_then(std::result::Result::ok);
+
+        let negotiation = Negotiation::new(extensions, &options, role)?;
+        Ok(Self::new(role, io, Bytes::new(), negotiation))
     }
 
     /// Creates a new WebSocket from an existing stream.
@@ -1329,8 +1418,152 @@ fn generate_key() -> String {
     BASE64_STANDARD.encode(input)
 }
 
+/// Connects and handshakes using the HTTP version selected on the builder.
+///
+/// Unlike [`WebSocket::connect_priv`] this always resolves to an [`HttpWebSocket`],
+/// because an HTTP/2 WebSocket is one stream of a multiplexed connection and there is no
+/// socket to hand back. Keeping the return type the same for both versions is what lets
+/// [`HttpVersion::Auto`] decide at runtime.
+#[cfg(feature = "http2")]
+async fn connect_versioned(
+    url: Url,
+    tcp_address: Option<SocketAddr>,
+    connector: Option<TlsConnector>,
+    options: Options,
+    builder: HttpRequestBuilder,
+    version: HttpVersion,
+) -> Result<HttpWebSocket> {
+    let host = url.host().expect("hostname").to_string();
+
+    let tcp_stream = if let Some(tcp_address) = tcp_address {
+        TcpStream::connect(tcp_address).await?
+    } else {
+        let port = url.port_or_known_default().expect("port");
+        TcpStream::connect(format!("{host}:{port}")).await?
+    };
+
+    let _ = tcp_stream.set_nodelay(options.no_delay);
+
+    // Over plaintext there is no ALPN to consult, so the version has to be assumed:
+    // HTTP/2 means prior knowledge, anything else means HTTP/1.1.
+    let (stream, use_http2) = match url.scheme() {
+        "ws" => (
+            MaybeTlsStream::Plain(tcp_stream),
+            version == HttpVersion::Http2,
+        ),
+        "wss" => {
+            let connector = connector.unwrap_or_else(|| tls_connector_with_alpn(alpn_for(version)));
+            let domain = ServerName::try_from(host)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))?;
+
+            let tls_stream = connector.connect(domain, tcp_stream).await?;
+            let negotiated_h2 = tls_stream.get_ref().1.alpn_protocol() == Some(b"h2");
+
+            // A custom connector may not offer h2 at all, so an explicit Http2 request is
+            // honored even when ALPN stayed silent. Auto follows what the server picked.
+            let use_http2 = match version {
+                HttpVersion::Http1 => false,
+                HttpVersion::Http2 => true,
+                HttpVersion::Auto => negotiated_h2,
+            };
+
+            (MaybeTlsStream::Tls(tls_stream), use_http2)
+        }
+        _ => return Err(WebSocketError::InvalidHttpScheme),
+    };
+
+    if use_http2 {
+        http2::handshake(url, stream, options, builder).await
+    } else {
+        handshake_http1_upgraded(url, stream, options, builder).await
+    }
+}
+
+/// Runs the HTTP/1.1 handshake but keeps hyper's upgraded stream instead of downcasting.
+///
+/// [`WebSocket::handshake_with_request`] recovers the original stream type so callers get
+/// their socket back. The versioned path cannot do that, since it has to produce the same
+/// type whichever HTTP version the handshake settles on.
+#[cfg(feature = "http2")]
+async fn handshake_http1_upgraded<S>(
+    url: Url,
+    io: S,
+    options: Options,
+    builder: HttpRequestBuilder,
+) -> Result<HttpWebSocket>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    let mut builder = builder;
+    if !builder
+        .headers_ref()
+        .expect("header")
+        .contains_key(header::HOST)
+    {
+        let host = url.host().expect("hostname").to_string();
+        let host_header = if url.port().is_some() {
+            format!("{host}:{}", url.port_or_known_default().expect("port"))
+        } else {
+            host
+        };
+        builder = builder.header(header::HOST, host_header.as_str());
+    }
+
+    let mut req = builder
+        .method("GET")
+        .uri(&url[url::Position::BeforePath..])
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "upgrade")
+        .header(header::SEC_WEBSOCKET_KEY, generate_key())
+        .header(header::SEC_WEBSOCKET_VERSION, "13")
+        .body(Empty::<Bytes>::new())
+        .expect("request build");
+
+    if let Some(compression) = options.compression.as_ref() {
+        let extensions = WebSocketExtensions::from(compression);
+        let header_value = extensions.to_string().parse().expect("extensions header");
+        req.headers_mut()
+            .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
+    }
+
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(io)).await?;
+
+    tokio::spawn(async move {
+        if let Err(err) = conn.with_upgrades().await {
+            log::debug!("http1 connection closed: {err:?}");
+        }
+    });
+
+    let mut response = sender.send_request(req).await?;
+    let negotiated = verify(&response, options)?;
+
+    let upgraded = hyper::upgrade::on(&mut response).await?;
+
+    Ok(WebSocket::new(
+        Role::Client,
+        HttpStream::from(TokioIo::new(upgraded)),
+        Bytes::new(),
+        negotiated,
+    ))
+}
+
+/// Returns the ALPN protocols to offer for a given HTTP version preference.
+#[cfg(feature = "http2")]
+fn alpn_for(version: HttpVersion) -> Vec<Vec<u8>> {
+    match version {
+        HttpVersion::Http1 => vec![b"http/1.1".to_vec()],
+        HttpVersion::Http2 => vec![b"h2".to_vec()],
+        HttpVersion::Auto => vec![b"h2".to_vec(), b"http/1.1".to_vec()],
+    }
+}
+
 /// Creates a TLS connector with root certificates for secure WebSocket connections.
 fn tls_connector() -> TlsConnector {
+    tls_connector_with_alpn(vec![b"http/1.1".to_vec()])
+}
+
+/// Creates a TLS connector offering the given ALPN protocols.
+fn tls_connector_with_alpn(alpn_protocols: Vec<Vec<u8>>) -> TlsConnector {
     let mut root_cert_store = rustls::RootCertStore::empty();
     root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| TrustAnchor {
         subject: ta.subject.clone(),
@@ -1367,7 +1600,7 @@ Either:
         .expect("versions")
         .with_root_certificates(root_cert_store)
         .with_no_client_auth();
-    config.alpn_protocols = vec!["http/1.1".into()];
+    config.alpn_protocols = alpn_protocols;
 
     TlsConnector::from(Arc::new(config))
 }

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -872,74 +872,109 @@ where
         url: Url,
         io: S,
         options: Options,
-        mut builder: HttpRequestBuilder,
+        builder: HttpRequestBuilder,
     ) -> Result<WebSocket<S>> {
-        if !builder
-            .headers_ref()
-            .expect("header")
-            .contains_key(header::HOST)
-        {
-            let host = url.host().expect("hostname").to_string();
+        let (upgraded, negotiated) = http1_upgrade(url, io, options, builder).await?;
 
-            let is_port_defined = url.port().is_some();
-            let port = url.port_or_known_default().expect("port");
-            let host_header = if is_port_defined {
-                format!("{host}:{port}")
-            } else {
-                host
-            };
-
-            builder = builder.header(header::HOST, host_header.as_str());
-        }
-
-        let target_url = &url[url::Position::BeforePath..];
-
-        let mut req = builder
-            .method("GET")
-            .uri(target_url)
-            .header(header::UPGRADE, "websocket")
-            .header(header::CONNECTION, "upgrade")
-            .header(header::SEC_WEBSOCKET_KEY, generate_key())
-            .header(header::SEC_WEBSOCKET_VERSION, "13")
-            .body(Empty::<Bytes>::new())
-            .expect("request build");
-
-        if let Some(compression) = options.compression.as_ref() {
-            let extensions = WebSocketExtensions::from(compression);
-            let header_value = extensions.to_string().parse().unwrap();
-            req.headers_mut()
-                .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
-        }
-
-        let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(io)).await?;
-
-        #[cfg(not(feature = "smol"))]
-        tokio::spawn(async move {
-            if let Err(err) = conn.with_upgrades().await {
-                log::error!("upgrading connection: {:?}", err);
-            }
-        });
-
-        #[cfg(feature = "smol")]
-        smol::spawn(async move {
-            if let Err(err) = conn.with_upgrades().await {
-                log::error!("upgrading connection: {:?}", err);
-            }
-        })
-        .detach();
-
-        let mut response = sender.send_request(req).await?;
-        let negotiated = verify(&response, options)?;
-
-        let upgraded = hyper::upgrade::on(&mut response).await?;
-        let parts = upgraded.downcast::<TokioIo<S>>().unwrap();
-
-        // Extract the original stream and any leftover read buffer
+        // Recover the caller's own stream, along with anything the codec read past the
+        // end of the response.
+        let parts = upgraded
+            .downcast::<TokioIo<S>>()
+            .expect("downcast own stream");
         let stream = parts.io.into_inner();
-        let read_buf = parts.read_buf;
 
-        Ok(WebSocket::new(Role::Client, stream, read_buf, negotiated))
+        Ok(WebSocket::new(
+            Role::Client,
+            stream,
+            parts.read_buf,
+            negotiated,
+        ))
     }
+}
+
+/// Runs the RFC 6455 handshake and returns hyper's upgraded stream.
+///
+/// The two client entry points differ only in what they do with that stream:
+/// [`WebSocket::handshake_with_request`] downcasts it back to the caller's own type,
+/// while the version-selecting path keeps it as an [`HttpStream`] so both HTTP versions
+/// produce one type. Everything before that, defaulting the `Host` header, building the
+/// request, offering compression, driving the connection and checking the response, is
+/// the same work and lives here.
+async fn http1_upgrade<S>(
+    url: Url,
+    io: S,
+    options: Options,
+    mut builder: HttpRequestBuilder,
+) -> Result<(Upgraded, Negotiation)>
+where
+    S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
+{
+    if !builder
+        .headers_ref()
+        .expect("header")
+        .contains_key(header::HOST)
+    {
+        let host = url.host().expect("hostname").to_string();
+
+        let is_port_defined = url.port().is_some();
+        let port = url.port_or_known_default().expect("port");
+        let host_header = if is_port_defined {
+            format!("{host}:{port}")
+        } else {
+            host
+        };
+
+        builder = builder.header(header::HOST, host_header.as_str());
+    }
+
+    let target_url = &url[url::Position::BeforePath..];
+
+    let mut req = builder
+        .method("GET")
+        .uri(target_url)
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "upgrade")
+        .header(header::SEC_WEBSOCKET_KEY, generate_key())
+        .header(header::SEC_WEBSOCKET_VERSION, "13")
+        .body(Empty::<Bytes>::new())
+        .expect("request build");
+
+    if let Some(compression) = options.compression.as_ref() {
+        let extensions = WebSocketExtensions::from(compression);
+        let header_value = extensions.to_string().parse().expect("extensions header");
+        req.headers_mut()
+            .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
+    }
+
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(io)).await?;
+
+    spawn_connection(async move {
+        if let Err(err) = conn.with_upgrades().await {
+            log::debug!("http1 connection closed: {err:?}");
+        }
+    });
+
+    let mut response = sender.send_request(req).await?;
+    let negotiated = verify(&response, options)?;
+
+    let upgraded = hyper::upgrade::on(&mut response).await?;
+
+    Ok((upgraded, negotiated))
+}
+
+/// Drives a hyper connection in the background on whichever runtime is enabled.
+///
+/// Every client handshake needs this, and picking `tokio::spawn` unconditionally would
+/// panic under the `smol` feature, where no tokio runtime is running.
+pub(crate) fn spawn_connection<F>(fut: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    #[cfg(not(feature = "smol"))]
+    tokio::spawn(fut);
+
+    #[cfg(feature = "smol")]
+    smol::spawn(fut).detach();
 }
 
 impl WebSocket<HttpStream> {
@@ -1040,12 +1075,7 @@ impl WebSocket<HttpStream> {
             return Err(WebSocketError::InvalidSecWebsocketVersion);
         }
 
-        let maybe_compression = request
-            .headers()
-            .get(header::SEC_WEBSOCKET_EXTENSIONS)
-            .and_then(|h| h.to_str().ok())
-            .map(WebSocketExtensions::from_str)
-            .and_then(std::result::Result::ok);
+        let maybe_compression = WebSocketExtensions::from_headers(request.headers());
 
         let mut response = Response::builder()
             .status(hyper::StatusCode::SWITCHING_PROTOCOLS)
@@ -1058,22 +1088,15 @@ impl WebSocket<HttpStream> {
             .body(Empty::new())
             .expect("bug: failed to build response");
 
-        let extensions = if let Some(client_compression) = maybe_compression {
-            if let Some(server_compression) = options.compression.as_ref() {
-                let offer = server_compression.merge(&client_compression);
+        let extensions =
+            WebSocketExtensions::agree(options.compression.as_ref(), maybe_compression);
 
-                let header_value = offer.to_string().parse().unwrap();
-                response
-                    .headers_mut()
-                    .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
-
-                Some(offer)
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        if let Some(offer) = extensions.as_ref() {
+            let header_value = offer.to_string().parse().expect("extensions header");
+            response
+                .headers_mut()
+                .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
+        }
 
         let stream = UpgradeFut {
             inner: hyper::upgrade::on(request),
@@ -1353,11 +1376,7 @@ fn verify_reqwest(response: &reqwest::Response, options: Options) -> Result<Nego
         return Err(WebSocketError::InvalidConnectionHeader);
     }
 
-    let extensions = headers
-        .get(reqwest::header::SEC_WEBSOCKET_EXTENSIONS)
-        .and_then(|h| h.to_str().ok())
-        .map(WebSocketExtensions::from_str)
-        .and_then(std::result::Result::ok);
+    let extensions = WebSocketExtensions::from_headers(headers);
 
     Negotiation::new(extensions, &options, Role::Client)
 }
@@ -1403,11 +1422,7 @@ fn verify(response: &Response<Incoming>, options: Options) -> Result<Negotiation
         return Err(WebSocketError::InvalidConnectionHeader);
     }
 
-    let extensions = headers
-        .get(header::SEC_WEBSOCKET_EXTENSIONS)
-        .and_then(|h| h.to_str().ok())
-        .map(WebSocketExtensions::from_str)
-        .and_then(std::result::Result::ok);
+    let extensions = WebSocketExtensions::from_headers(headers);
 
     Negotiation::new(extensions, &options, Role::Client)
 }
@@ -1469,8 +1484,8 @@ async fn connect_versioned(
 /// Runs the HTTP/1.1 handshake but keeps hyper's upgraded stream instead of downcasting.
 ///
 /// [`WebSocket::handshake_with_request`] recovers the original stream type so callers get
-/// their socket back. The versioned path cannot do that, since it has to produce the same
-/// type whichever HTTP version the handshake settles on.
+/// their socket back. The version-selecting path cannot do that, since it has to produce
+/// the same type whichever HTTP version the handshake settles on.
 #[cfg(feature = "http2")]
 async fn handshake_http1_upgraded<S>(
     url: Url,
@@ -1481,50 +1496,7 @@ async fn handshake_http1_upgraded<S>(
 where
     S: AsyncRead + AsyncWrite + Send + Unpin + 'static,
 {
-    let mut builder = builder;
-    if !builder
-        .headers_ref()
-        .expect("header")
-        .contains_key(header::HOST)
-    {
-        let host = url.host().expect("hostname").to_string();
-        let host_header = if url.port().is_some() {
-            format!("{host}:{}", url.port_or_known_default().expect("port"))
-        } else {
-            host
-        };
-        builder = builder.header(header::HOST, host_header.as_str());
-    }
-
-    let mut req = builder
-        .method("GET")
-        .uri(&url[url::Position::BeforePath..])
-        .header(header::UPGRADE, "websocket")
-        .header(header::CONNECTION, "upgrade")
-        .header(header::SEC_WEBSOCKET_KEY, generate_key())
-        .header(header::SEC_WEBSOCKET_VERSION, "13")
-        .body(Empty::<Bytes>::new())
-        .expect("request build");
-
-    if let Some(compression) = options.compression.as_ref() {
-        let extensions = WebSocketExtensions::from(compression);
-        let header_value = extensions.to_string().parse().expect("extensions header");
-        req.headers_mut()
-            .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
-    }
-
-    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(io)).await?;
-
-    tokio::spawn(async move {
-        if let Err(err) = conn.with_upgrades().await {
-            log::debug!("http1 connection closed: {err:?}");
-        }
-    });
-
-    let mut response = sender.send_request(req).await?;
-    let negotiated = verify(&response, options)?;
-
-    let upgraded = hyper::upgrade::on(&mut response).await?;
+    let (upgraded, negotiated) = http1_upgrade(url, io, options, builder).await?;
 
     Ok(WebSocket::new(
         Role::Client,

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1096,7 +1096,7 @@ impl WebSocket<HttpStream> {
     /// the version check and extension negotiation, is the same either way.
     fn handshake_response<B>(request: &Request<B>) -> Result<hyper::http::response::Builder> {
         #[cfg(feature = "http2")]
-        if http2::is_extended_connect(request) {
+        if http2::is_extended_connect(request.method(), request.extensions()) {
             return Ok(Response::builder().status(StatusCode::OK));
         }
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -156,7 +156,7 @@ use url::Url;
 // Re-exports
 pub use crate::stream::MaybeTlsStream;
 #[cfg(feature = "http2")]
-pub use builder::{Http2WebSocketBuilder, HttpVersion};
+pub use builder::HttpVersion;
 pub use builder::{HttpRequest, HttpRequestBuilder, WebSocketBuilder};
 pub use frame::{Frame, OpCode};
 pub use options::{CompressionLevel, DeflateOptions, Fragmentation, Options};

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -1056,15 +1056,8 @@ impl WebSocket<HttpStream> {
     ) -> UpgradeResult {
         let request = request.borrow_mut();
 
-        #[cfg(feature = "http2")]
-        if http2::is_extended_connect(request) {
-            return http2::upgrade(request, options);
-        }
-
-        let key = request
-            .headers()
-            .get(header::SEC_WEBSOCKET_KEY)
-            .ok_or(WebSocketError::MissingSecWebSocketKey)?;
+        // Only the opening line of the response depends on which handshake was used.
+        let builder = Self::handshake_response(request)?;
 
         if request
             .headers()
@@ -1075,28 +1068,18 @@ impl WebSocket<HttpStream> {
             return Err(WebSocketError::InvalidSecWebsocketVersion);
         }
 
-        let maybe_compression = WebSocketExtensions::from_headers(request.headers());
+        let client_extensions = WebSocketExtensions::from_headers(request.headers());
+        let extensions =
+            WebSocketExtensions::agree(options.compression.as_ref(), client_extensions);
 
-        let mut response = Response::builder()
-            .status(hyper::StatusCode::SWITCHING_PROTOCOLS)
-            .header(hyper::header::CONNECTION, "upgrade")
-            .header(hyper::header::UPGRADE, "websocket")
-            .header(
-                header::SEC_WEBSOCKET_ACCEPT,
-                upgrade::sec_websocket_protocol(key.as_bytes()),
-            )
+        let builder = match extensions.as_ref() {
+            Some(offer) => builder.header(header::SEC_WEBSOCKET_EXTENSIONS, offer.to_string()),
+            None => builder,
+        };
+
+        let response = builder
             .body(Empty::new())
             .expect("bug: failed to build response");
-
-        let extensions =
-            WebSocketExtensions::agree(options.compression.as_ref(), maybe_compression);
-
-        if let Some(offer) = extensions.as_ref() {
-            let header_value = offer.to_string().parse().expect("extensions header");
-            response
-                .headers_mut()
-                .insert(header::SEC_WEBSOCKET_EXTENSIONS, header_value);
-        }
 
         let stream = UpgradeFut {
             inner: hyper::upgrade::on(request),
@@ -1104,6 +1087,32 @@ impl WebSocket<HttpStream> {
         };
 
         Ok((response, stream))
+    }
+
+    /// Starts the handshake response for whichever handshake the request used.
+    ///
+    /// This is the whole difference between the two on the server: RFC 8441 answers `200`
+    /// and has no key to echo, RFC 6455 answers `101` and must echo one. What follows,
+    /// the version check and extension negotiation, is the same either way.
+    fn handshake_response<B>(request: &Request<B>) -> Result<hyper::http::response::Builder> {
+        #[cfg(feature = "http2")]
+        if http2::is_extended_connect(request) {
+            return Ok(Response::builder().status(StatusCode::OK));
+        }
+
+        let key = request
+            .headers()
+            .get(header::SEC_WEBSOCKET_KEY)
+            .ok_or(WebSocketError::MissingSecWebSocketKey)?;
+
+        Ok(Response::builder()
+            .status(StatusCode::SWITCHING_PROTOCOLS)
+            .header(header::CONNECTION, "upgrade")
+            .header(header::UPGRADE, "websocket")
+            .header(
+                header::SEC_WEBSOCKET_ACCEPT,
+                upgrade::sec_websocket_protocol(key.as_bytes()),
+            ))
     }
 }
 

--- a/src/native/options.rs
+++ b/src/native/options.rs
@@ -700,7 +700,7 @@ impl DeflateOptions {
     }
 
     /// Called by the server when upgrading.
-    pub(super) fn merge(&self, offered: &WebSocketExtensions) -> WebSocketExtensions {
+    pub(crate) fn merge(&self, offered: &WebSocketExtensions) -> WebSocketExtensions {
         WebSocketExtensions {
             // Accept client's no_context_takeover settings
             client_no_context_takeover: offered.client_no_context_takeover

--- a/src/native/upgrade.rs
+++ b/src/native/upgrade.rs
@@ -68,9 +68,10 @@ use {
 #[cfg_attr(docsrs, doc(cfg(feature = "axum")))]
 #[cfg(feature = "axum")]
 pub struct IncomingUpgrade {
-    /// The Sec-WebSocket-Key header value from the client. This value is used for the WebSocket
-    /// handshake as required by RFC 6455.
-    key: String,
+    /// The pre-computed `Sec-WebSocket-Accept` value derived from the client's
+    /// `Sec-WebSocket-Key`. `None` for RFC 8441 extended CONNECT requests, which carry no
+    /// key and are answered with `200` rather than `101`.
+    key: Option<String>,
 
     /// The Hyper upgrade future used to complete the protocol switch from HTTP to WebSocket.
     /// This handles the low-level protocol transition after handshake is complete.
@@ -131,11 +132,16 @@ impl IncomingUpgrade {
     /// - Per-message compression parameters are synchronized
     /// - Compression context is initialized after upgrade
     pub fn upgrade(self, options: Options) -> Result<(Response<Empty<Bytes>>, UpgradeFut)> {
-        let builder = Response::builder()
-            .status(hyper::StatusCode::SWITCHING_PROTOCOLS)
-            .header(header::CONNECTION, "upgrade")
-            .header(header::UPGRADE, "websocket")
-            .header(header::SEC_WEBSOCKET_ACCEPT, self.key);
+        // RFC 8441 answers 200 with no Upgrade, Connection or Accept headers; RFC 6455
+        // answers 101 with all three.
+        let builder = match self.key {
+            Some(key) => Response::builder()
+                .status(hyper::StatusCode::SWITCHING_PROTOCOLS)
+                .header(header::CONNECTION, "upgrade")
+                .header(header::UPGRADE, "websocket")
+                .header(header::SEC_WEBSOCKET_ACCEPT, key),
+            None => Response::builder().status(hyper::StatusCode::OK),
+        };
 
         let (builder, extensions) = match (self.extensions, options.compression.as_ref()) {
             (Some(client_offer), Some(server_offer)) => {
@@ -206,10 +212,22 @@ where
         use std::str::FromStr;
 
         async move {
-            let key = parts
-                .headers
-                .get(header::SEC_WEBSOCKET_KEY)
-                .ok_or(http::StatusCode::BAD_REQUEST)?;
+            // RFC 8441 drops the key exchange, so only the HTTP/1.1 handshake requires one.
+            #[cfg(feature = "http2")]
+            let is_extended_connect =
+                super::http2::is_websocket_connect(&parts.method, &parts.extensions);
+            #[cfg(not(feature = "http2"))]
+            let is_extended_connect = false;
+
+            let key = if is_extended_connect {
+                None
+            } else {
+                let key = parts
+                    .headers
+                    .get(header::SEC_WEBSOCKET_KEY)
+                    .ok_or(http::StatusCode::BAD_REQUEST)?;
+                Some(sec_websocket_protocol(key.as_bytes()))
+            };
 
             if parts
                 .headers
@@ -235,7 +253,7 @@ where
             Ok(Self {
                 on_upgrade,
                 extensions,
-                key: sec_websocket_protocol(key.as_bytes()),
+                key,
             })
         }
     }

--- a/src/native/upgrade.rs
+++ b/src/native/upgrade.rs
@@ -19,7 +19,6 @@ use {
     crate::{compression::WebSocketExtensions, Result},
     http_body_util::Empty,
     hyper::{header, Response},
-    std::future::Future,
 };
 
 /// Represents an incoming WebSocket upgrade request that can be converted into a WebSocket connection.
@@ -143,13 +142,11 @@ impl IncomingUpgrade {
             None => Response::builder().status(hyper::StatusCode::OK),
         };
 
-        let (builder, extensions) = match (self.extensions, options.compression.as_ref()) {
-            (Some(client_offer), Some(server_offer)) => {
-                let offer = server_offer.merge(&client_offer);
-                let response = builder.header(header::SEC_WEBSOCKET_EXTENSIONS, offer.to_string());
-                (response, Some(offer))
-            }
-            _ => (builder, None),
+        let extensions = WebSocketExtensions::agree(options.compression.as_ref(), self.extensions);
+
+        let builder = match extensions.as_ref() {
+            Some(offer) => builder.header(header::SEC_WEBSOCKET_EXTENSIONS, offer.to_string()),
+            None => builder,
         };
 
         let response = builder
@@ -205,57 +202,48 @@ where
     /// - The protocol version (must be 13)
     /// - Any extension offers from the client
     /// - The upgrade future from Hyper
-    fn from_request_parts(
+    async fn from_request_parts(
         parts: &mut http::request::Parts,
         _state: &S,
-    ) -> impl Future<Output = std::result::Result<Self, Self::Rejection>> + Send {
-        use std::str::FromStr;
+    ) -> std::result::Result<Self, Self::Rejection> {
+        // RFC 8441 drops the key exchange, so only the HTTP/1.1 handshake requires one.
+        #[cfg(feature = "http2")]
+        let is_extended_connect =
+            super::http2::is_websocket_connect(&parts.method, &parts.extensions);
+        #[cfg(not(feature = "http2"))]
+        let is_extended_connect = false;
 
-        async move {
-            // RFC 8441 drops the key exchange, so only the HTTP/1.1 handshake requires one.
-            #[cfg(feature = "http2")]
-            let is_extended_connect =
-                super::http2::is_websocket_connect(&parts.method, &parts.extensions);
-            #[cfg(not(feature = "http2"))]
-            let is_extended_connect = false;
-
-            let key = if is_extended_connect {
-                None
-            } else {
-                let key = parts
-                    .headers
-                    .get(header::SEC_WEBSOCKET_KEY)
-                    .ok_or(http::StatusCode::BAD_REQUEST)?;
-                Some(sec_websocket_protocol(key.as_bytes()))
-            };
-
-            if parts
+        let key = if is_extended_connect {
+            None
+        } else {
+            let key = parts
                 .headers
-                .get(header::SEC_WEBSOCKET_VERSION)
-                .map(|v| v.as_bytes())
-                != Some(b"13")
-            {
-                return Err(hyper::StatusCode::BAD_REQUEST);
-            }
+                .get(header::SEC_WEBSOCKET_KEY)
+                .ok_or(http::StatusCode::BAD_REQUEST)?;
+            Some(sec_websocket_protocol(key.as_bytes()))
+        };
 
-            let extensions = parts
-                .headers
-                .get(header::SEC_WEBSOCKET_EXTENSIONS)
-                .and_then(|h| h.to_str().ok())
-                .map(WebSocketExtensions::from_str)
-                .and_then(std::result::Result::ok);
-
-            let on_upgrade = parts
-                .extensions
-                .remove::<hyper::upgrade::OnUpgrade>()
-                .ok_or(hyper::StatusCode::BAD_REQUEST)?;
-
-            Ok(Self {
-                on_upgrade,
-                extensions,
-                key,
-            })
+        if parts
+            .headers
+            .get(header::SEC_WEBSOCKET_VERSION)
+            .map(|v| v.as_bytes())
+            != Some(b"13")
+        {
+            return Err(hyper::StatusCode::BAD_REQUEST);
         }
+
+        let extensions = WebSocketExtensions::from_headers(&parts.headers);
+
+        let on_upgrade = parts
+            .extensions
+            .remove::<hyper::upgrade::OnUpgrade>()
+            .ok_or(hyper::StatusCode::BAD_REQUEST)?;
+
+        Ok(Self {
+            on_upgrade,
+            extensions,
+            key,
+        })
     }
 }
 

--- a/src/native/upgrade.rs
+++ b/src/native/upgrade.rs
@@ -209,7 +209,7 @@ where
         // RFC 8441 drops the key exchange, so only the HTTP/1.1 handshake requires one.
         #[cfg(feature = "http2")]
         let is_extended_connect =
-            super::http2::is_websocket_connect(&parts.method, &parts.extensions);
+            super::http2::is_extended_connect(&parts.method, &parts.extensions);
         #[cfg(not(feature = "http2"))]
         let is_extended_connect = false;
 

--- a/tests/axum_upgrade.rs
+++ b/tests/axum_upgrade.rs
@@ -1,0 +1,143 @@
+//! The axum `IncomingUpgrade` extractor over HTTP/1.1.
+//!
+//! Adding RFC 8441 support made the extractor's `Sec-WebSocket-Accept` optional, since an
+//! extended CONNECT has no key to echo. These tests pin the HTTP/1.1 response so that
+//! change cannot alter the RFC 6455 handshake, and they deliberately do not require the
+//! `http2` feature: without it the extended-CONNECT branch is compiled out, which is the
+//! configuration the autobahn suite runs.
+
+#![cfg(all(feature = "axum", not(target_arch = "wasm32")))]
+
+use std::net::SocketAddr;
+
+use axum::{response::IntoResponse, routing::get, Router};
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use http_body_util::Empty;
+use hyper::{header, server::conn::http1, StatusCode};
+use hyper_util::{rt::TokioIo, service::TowerToHyperService};
+use tokio::net::{TcpListener, TcpStream};
+use yawc::{frame::OpCode, Frame, IncomingUpgrade, Options, WebSocket};
+
+/// The example key and its expected accept value from RFC 6455 section 1.3.
+const SAMPLE_KEY: &str = "dGhlIHNhbXBsZSBub25jZQ==";
+const SAMPLE_ACCEPT: &str = "s3pPLMBiTxaQ9kYGzzhZRbK+xOo=";
+
+async fn ws_handler(ws: IncomingUpgrade) -> impl IntoResponse {
+    let (response, fut) = ws.upgrade(Options::default()).unwrap();
+
+    tokio::spawn(async move {
+        let Ok(mut ws) = fut.await else { return };
+        while let Some(frame) = ws.next().await {
+            if matches!(frame.opcode(), OpCode::Text | OpCode::Binary)
+                && ws.send(frame).await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    response
+}
+
+async fn spawn_server() -> SocketAddr {
+    let app = Router::new().route("/chat", get(ws_handler));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let service = TowerToHyperService::new(app.clone());
+            tokio::spawn(async move {
+                let _ = http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .with_upgrades()
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+#[tokio::test]
+async fn answers_101_with_the_rfc6455_accept_value() {
+    let addr = spawn_server().await;
+
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+        .await
+        .unwrap();
+    tokio::spawn(conn.with_upgrades());
+
+    let request = hyper::Request::builder()
+        .method("GET")
+        .uri("/chat")
+        .header(header::HOST, "localhost")
+        .header(header::UPGRADE, "websocket")
+        .header(header::CONNECTION, "upgrade")
+        .header(header::SEC_WEBSOCKET_KEY, SAMPLE_KEY)
+        .header(header::SEC_WEBSOCKET_VERSION, "13")
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+
+    let response = sender.send_request(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::SWITCHING_PROTOCOLS);
+    assert_eq!(
+        response
+            .headers()
+            .get(header::SEC_WEBSOCKET_ACCEPT)
+            .unwrap(),
+        SAMPLE_ACCEPT,
+    );
+    assert_eq!(
+        response.headers().get(header::UPGRADE).unwrap(),
+        "websocket"
+    );
+    assert_eq!(
+        response.headers().get(header::CONNECTION).unwrap(),
+        "upgrade"
+    );
+}
+
+#[tokio::test]
+async fn echoes_over_the_http1_handshake() {
+    let addr = spawn_server().await;
+
+    let mut ws = WebSocket::connect(format!("ws://{addr}/chat").parse().unwrap())
+        .await
+        .unwrap();
+
+    ws.send(Frame::text("still rfc 6455")).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Text);
+    assert_eq!(frame.payload().as_ref(), b"still rfc 6455");
+}
+
+#[tokio::test]
+async fn rejects_a_request_with_no_key() {
+    // The key is only optional for extended CONNECT. Over HTTP/1.1 a missing key must
+    // still be turned away rather than producing a keyless 200.
+    let addr = spawn_server().await;
+
+    let stream = TcpStream::connect(addr).await.unwrap();
+    let (mut sender, conn) = hyper::client::conn::http1::handshake(TokioIo::new(stream))
+        .await
+        .unwrap();
+    tokio::spawn(conn);
+
+    let request = hyper::Request::builder()
+        .method("GET")
+        .uri("/chat")
+        .header(header::HOST, "localhost")
+        .header(header::SEC_WEBSOCKET_VERSION, "13")
+        .body(Empty::<Bytes>::new())
+        .unwrap();
+
+    let response = sender.send_request(request).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}

--- a/tests/from_stream.rs
+++ b/tests/from_stream.rs
@@ -4,6 +4,10 @@
 //! [`WebSocket::from_stream_with_extensions`], which perform no handshake and take the
 //! caller's word for the role and negotiated extensions.
 
+// The wasm build compiles integration tests too, and neither this API nor tokio's duplex
+// exists there.
+#![cfg(not(target_arch = "wasm32"))]
+
 use futures::{SinkExt, StreamExt};
 use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
 use yawc::{frame::OpCode, Frame, Options, Role, WebSocket, WebSocketError};

--- a/tests/from_stream.rs
+++ b/tests/from_stream.rs
@@ -1,0 +1,199 @@
+//! Tests for wrapping a stream that was handshaked elsewhere.
+//!
+//! These cover [`WebSocket::from_stream`] and
+//! [`WebSocket::from_stream_with_extensions`], which perform no handshake and take the
+//! caller's word for the role and negotiated extensions.
+
+use futures::{SinkExt, StreamExt};
+use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
+use yawc::{frame::OpCode, Frame, Options, Role, WebSocket, WebSocketError};
+
+/// Builds a connected client/server pair over an in-memory duplex.
+fn pair(options: Options) -> (WebSocket<DuplexStream>, WebSocket<DuplexStream>) {
+    let (client_io, server_io) = duplex(1024 * 1024);
+
+    let client = WebSocket::from_stream(client_io, Role::Client, options.clone()).unwrap();
+    let server = WebSocket::from_stream(server_io, Role::Server, options).unwrap();
+
+    (client, server)
+}
+
+#[tokio::test]
+async fn round_trips_in_both_directions() {
+    let (mut client, mut server) = pair(Options::default());
+
+    client.send(Frame::text("ping from client")).await.unwrap();
+    let frame = server.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Text);
+    assert_eq!(frame.payload().as_ref(), b"ping from client");
+
+    server.send(Frame::binary(vec![9, 8, 7])).await.unwrap();
+    let frame = client.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Binary);
+    assert_eq!(frame.payload().as_ref(), &[9, 8, 7]);
+}
+
+#[tokio::test]
+async fn role_client_masks_and_role_server_does_not() {
+    // Read the raw bytes off the wire rather than through a peer WebSocket, so the mask
+    // bit is observed directly. Getting the role wrong is the main way to misuse this
+    // API, so it is worth pinning down.
+    let (client_io, mut raw) = duplex(1024);
+    let mut client = WebSocket::from_stream(client_io, Role::Client, Options::default()).unwrap();
+    client.send(Frame::text("hi")).await.unwrap();
+
+    let mut header = [0u8; 2];
+    raw.read_exact(&mut header).await.unwrap();
+    assert_eq!(header[0], 0x81, "expected FIN + text opcode");
+    assert_eq!(header[1] & 0x80, 0x80, "client frames must be masked");
+    assert_eq!(header[1] & 0x7f, 2, "payload length");
+
+    let (server_io, mut raw) = duplex(1024);
+    let mut server = WebSocket::from_stream(server_io, Role::Server, Options::default()).unwrap();
+    server.send(Frame::text("hi")).await.unwrap();
+
+    let mut header = [0u8; 2];
+    raw.read_exact(&mut header).await.unwrap();
+    assert_eq!(header[0], 0x81);
+    assert_eq!(header[1] & 0x80, 0x00, "server frames must not be masked");
+}
+
+#[tokio::test]
+async fn honors_negotiated_permessage_deflate() {
+    let (client_io, server_io) = duplex(1024 * 1024);
+    let options = Options::default().with_balanced_compression();
+
+    let mut client = WebSocket::from_stream_with_extensions(
+        client_io,
+        Role::Client,
+        Some("permessage-deflate"),
+        options.clone(),
+    )
+    .unwrap();
+
+    let mut server = WebSocket::from_stream_with_extensions(
+        server_io,
+        Role::Server,
+        Some("permessage-deflate"),
+        options,
+    )
+    .unwrap();
+
+    let payload = "compress me ".repeat(4096);
+    client.send(Frame::text(payload.clone())).await.unwrap();
+
+    let frame = server.next().await.unwrap();
+    assert_eq!(frame.payload().as_ref(), payload.as_bytes());
+}
+
+#[tokio::test]
+async fn compression_stays_off_when_not_negotiated() {
+    // Compression is enabled locally but the handshake agreed on nothing, so frames must
+    // go out uncompressed. A peer with no inflate context has to be able to read them.
+    let (client_io, server_io) = duplex(1024 * 1024);
+    let with_compression = Options::default().with_balanced_compression();
+
+    let mut client =
+        WebSocket::from_stream(client_io, Role::Client, with_compression.clone()).unwrap();
+    let mut server = WebSocket::from_stream(server_io, Role::Server, Options::default()).unwrap();
+
+    let payload = "plain ".repeat(1024);
+    client.send(Frame::text(payload.clone())).await.unwrap();
+
+    let frame = server.next().await.unwrap();
+    assert_eq!(frame.payload().as_ref(), payload.as_bytes());
+}
+
+#[tokio::test]
+async fn rejects_extensions_that_were_never_offered() {
+    // The peer agreed on permessage-deflate but this side has no compression configured,
+    // so there is no way to decode what arrives. Better to fail here than at read time.
+    let (io, _peer) = duplex(1024);
+
+    let result = WebSocket::from_stream_with_extensions(
+        io,
+        Role::Client,
+        Some("permessage-deflate"),
+        Options::default().without_compression(),
+    );
+
+    let err = match result {
+        Ok(_) => panic!("expected the unoffered extension to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(
+        matches!(err, WebSocketError::CompressionNotSupported),
+        "unexpected error: {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn ignores_an_unparseable_extensions_header() {
+    // Garbage in the header is treated as "nothing negotiated" rather than an error, so a
+    // caller passing through an odd header still gets a working connection.
+    let (client_io, server_io) = duplex(1024);
+
+    let mut client = WebSocket::from_stream_with_extensions(
+        client_io,
+        Role::Client,
+        Some("!!! not an extension !!!"),
+        Options::default(),
+    )
+    .unwrap();
+    let mut server = WebSocket::from_stream(server_io, Role::Server, Options::default()).unwrap();
+
+    client.send(Frame::text("still works")).await.unwrap();
+    assert_eq!(
+        server.next().await.unwrap().payload().as_ref(),
+        b"still works"
+    );
+}
+
+#[tokio::test]
+async fn control_frames_work_over_a_wrapped_stream() {
+    let (mut client, mut server) = pair(Options::default());
+
+    client
+        .send(Frame::ping(&b"are you there"[..]))
+        .await
+        .unwrap();
+
+    let frame = server.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Ping);
+
+    // The pong is queued as an obligated send and is only written when the server is
+    // polled again, so the server has to be driven alongside the client's read. Awaiting
+    // the client alone deadlocks. `biased` polls the server first so the pong is flushed
+    // before the client is checked.
+    let frame = tokio::select! {
+        biased;
+        unexpected = server.next() => {
+            panic!("server yielded an extra {:?} frame", unexpected.map(|f| f.opcode()))
+        }
+        frame = client.next() => frame.unwrap(),
+    };
+
+    assert_eq!(frame.opcode(), OpCode::Pong);
+    assert_eq!(frame.payload().as_ref(), b"are you there");
+}
+
+#[tokio::test]
+async fn reads_a_frame_written_by_hand() {
+    // Nothing in this path came from a yawc peer, which is the point: the stream is
+    // opaque and only has to carry well-formed RFC 6455 frames.
+    let (server_io, mut raw) = duplex(1024);
+    let mut server = WebSocket::from_stream(server_io, Role::Server, Options::default()).unwrap();
+
+    // FIN + text, masked, 5 bytes, mask key 0x01020304, "hello" masked with it.
+    let mask = [0x01, 0x02, 0x03, 0x04];
+    let mut frame = vec![0x81, 0x85];
+    frame.extend_from_slice(&mask);
+    frame.extend(b"hello".iter().zip(mask.iter().cycle()).map(|(b, m)| b ^ m));
+
+    raw.write_all(&frame).await.unwrap();
+
+    let received = server.next().await.unwrap();
+    assert_eq!(received.opcode(), OpCode::Text);
+    assert_eq!(received.payload().as_ref(), b"hello");
+}

--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -11,7 +11,12 @@ use std::{convert::Infallible, net::SocketAddr};
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
 use http_body_util::Empty;
-use hyper::{body::Incoming, server::conn::http2, service::service_fn, Request, Response};
+use hyper::{
+    body::Incoming,
+    server::conn::{http1, http2},
+    service::service_fn,
+    Request, Response,
+};
 use hyper_util::rt::{TokioExecutor, TokioIo};
 use tokio::net::TcpListener;
 use yawc::{
@@ -70,10 +75,39 @@ async fn handle(
     Ok(response)
 }
 
+/// Starts an HTTP/1.1 echo server, for checking the version selection falls back cleanly.
+async fn spawn_http1_echo_server() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let service = service_fn(|req| handle(req, Options::default()));
+                let _ = http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .with_upgrades()
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
 /// Connects to `addr` over HTTP/2 prior knowledge.
 async fn connect(addr: SocketAddr, options: Options) -> yawc::Result<HttpWebSocket> {
+    connect_with(addr, options, HttpVersion::Http2).await
+}
+
+/// Connects to `addr` with an explicit version selection.
+async fn connect_with(
+    addr: SocketAddr,
+    options: Options,
+    version: HttpVersion,
+) -> yawc::Result<HttpWebSocket> {
     WebSocket::connect(format!("ws://{addr}/chat").parse()?)
-        .http_version(HttpVersion::Http2)
+        .http_version(version)
         .with_options(options)
         .await
 }
@@ -203,6 +237,76 @@ async fn server_without_connect_protocol_is_reported_clearly() {
     assert!(
         err.is_handshake_error(),
         "expected a handshake error, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn ping_is_answered_with_a_pong() {
+    let addr = spawn_echo_server(Options::default()).await;
+    let mut ws = connect(addr, Options::default()).await.unwrap();
+
+    ws.send(Frame::ping(&b"knock"[..])).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Pong);
+    assert_eq!(frame.payload().as_ref(), b"knock");
+}
+
+#[tokio::test]
+async fn http1_version_uses_the_upgrade_handshake() {
+    // Selecting a version routes through the same builder as HTTP/2 but must still speak
+    // the RFC 6455 handshake, against a server that only knows HTTP/1.1.
+    let addr = spawn_http1_echo_server().await;
+    let mut ws = connect_with(addr, Options::default(), HttpVersion::Http1)
+        .await
+        .unwrap();
+
+    ws.send(Frame::text("over http/1.1")).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.payload().as_ref(), b"over http/1.1");
+}
+
+#[tokio::test]
+async fn auto_over_plaintext_falls_back_to_http1() {
+    // Plaintext has no ALPN to negotiate with, so Auto must not assume HTTP/2 prior
+    // knowledge; it has to work against an ordinary HTTP/1.1 server.
+    let addr = spawn_http1_echo_server().await;
+    let mut ws = connect_with(addr, Options::default(), HttpVersion::Auto)
+        .await
+        .unwrap();
+
+    ws.send(Frame::text("negotiated down")).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.payload().as_ref(), b"negotiated down");
+}
+
+#[tokio::test]
+async fn http1_version_carries_compression() {
+    let addr = spawn_http1_echo_server().await;
+    let options = Options::default().with_balanced_compression();
+
+    let mut ws = connect_with(addr, options, HttpVersion::Http1)
+        .await
+        .unwrap();
+
+    let payload = "deflate me ".repeat(2048);
+    ws.send(Frame::text(payload.clone())).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.payload().as_ref(), payload.as_bytes());
+}
+
+#[tokio::test]
+async fn http2_against_an_http1_server_fails_rather_than_hanging() {
+    let addr = spawn_http1_echo_server().await;
+
+    let result = connect_with(addr, Options::default(), HttpVersion::Http2).await;
+
+    assert!(
+        result.is_err(),
+        "expected HTTP/2 prior knowledge to fail against an HTTP/1.1 server"
     );
 }
 

--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -1,0 +1,234 @@
+//! End-to-end tests for WebSockets over HTTP/2 (RFC 8441).
+//!
+//! The server is hyper's HTTP/2 server with `enable_connect_protocol()`, the client is
+//! yawc's HTTP/2 handshake. Everything runs over plaintext TCP using HTTP/2 prior
+//! knowledge so the tests do not need certificates.
+
+#![cfg(feature = "http2")]
+
+use std::{convert::Infallible, net::SocketAddr};
+
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use http_body_util::Empty;
+use hyper::{body::Incoming, server::conn::http2, service::service_fn, Request, Response};
+use hyper_util::rt::{TokioExecutor, TokioIo};
+use tokio::net::TcpListener;
+use yawc::{
+    close::CloseCode, frame::OpCode, Frame, HttpVersion, HttpWebSocket, Options, WebSocket,
+};
+
+/// Starts an HTTP/2 echo server and returns the address it is listening on.
+///
+/// `enable_connect_protocol` is what makes the server advertise
+/// `SETTINGS_ENABLE_CONNECT_PROTOCOL`; without it hyper rejects extended CONNECT before
+/// the handler ever sees the request.
+async fn spawn_echo_server(options: Options) -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        loop {
+            let Ok((stream, _)) = listener.accept().await else {
+                return;
+            };
+            let options = options.clone();
+
+            tokio::spawn(async move {
+                let service = service_fn(move |req| handle(req, options.clone()));
+                let _ = http2::Builder::new(TokioExecutor::new())
+                    .enable_connect_protocol()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Upgrades an extended CONNECT request and echoes every data frame back.
+async fn handle(
+    mut req: Request<Incoming>,
+    options: Options,
+) -> Result<Response<Empty<Bytes>>, Infallible> {
+    let (response, fut) = WebSocket::upgrade_with_options(&mut req, options).unwrap();
+
+    tokio::spawn(async move {
+        let mut ws = fut.await.unwrap();
+        // Close is acknowledged automatically, but the reply is only written on the next
+        // poll, so the loop runs until the stream ends rather than breaking on Close.
+        while let Some(frame) = ws.next().await {
+            if matches!(frame.opcode(), OpCode::Text | OpCode::Binary)
+                && ws.send(frame).await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    Ok(response)
+}
+
+/// Connects to `addr` over HTTP/2 prior knowledge.
+async fn connect(addr: SocketAddr, options: Options) -> yawc::Result<HttpWebSocket> {
+    WebSocket::connect(format!("ws://{addr}/chat").parse()?)
+        .http_version(HttpVersion::Http2)
+        .with_options(options)
+        .await
+}
+
+#[tokio::test]
+async fn echoes_text_and_binary() {
+    let addr = spawn_echo_server(Options::default()).await;
+    let mut ws = connect(addr, Options::default()).await.unwrap();
+
+    ws.send(Frame::text("hello over h2")).await.unwrap();
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Text);
+    assert_eq!(frame.payload().as_ref(), b"hello over h2");
+
+    ws.send(Frame::binary(vec![1, 2, 3, 4])).await.unwrap();
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Binary);
+    assert_eq!(frame.payload().as_ref(), &[1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn echoes_payload_larger_than_one_h2_frame() {
+    // Comfortably past the 16 KiB default HTTP/2 frame size, so the payload is split
+    // across DATA frames and reassembled by the stream adapter.
+    let payload = vec![0xa5_u8; 256 * 1024];
+    let options = Options::default().with_limits(1024 * 1024, 4 * 1024 * 1024);
+
+    let addr = spawn_echo_server(options.clone()).await;
+    let mut ws = connect(addr, options).await.unwrap();
+
+    ws.send(Frame::binary(payload.clone())).await.unwrap();
+    let frame = ws.next().await.unwrap();
+
+    assert_eq!(frame.opcode(), OpCode::Binary);
+    assert_eq!(frame.payload().len(), payload.len());
+    assert_eq!(frame.payload().as_ref(), payload.as_slice());
+}
+
+#[tokio::test]
+async fn echoes_with_permessage_deflate() {
+    let options = Options::default().with_balanced_compression();
+
+    let addr = spawn_echo_server(options.clone()).await;
+    let mut ws = connect(addr, options).await.unwrap();
+
+    // Highly compressible, so this exercises the deflate path rather than the
+    // passthrough one.
+    let payload = "yawc ".repeat(4096);
+    ws.send(Frame::text(payload.clone())).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Text);
+    assert_eq!(frame.payload().as_ref(), payload.as_bytes());
+}
+
+#[tokio::test]
+async fn many_messages_in_sequence() {
+    let addr = spawn_echo_server(Options::default()).await;
+    let mut ws = connect(addr, Options::default()).await.unwrap();
+
+    for i in 0..100 {
+        let msg = format!("message {i}");
+        ws.send(Frame::text(msg.clone())).await.unwrap();
+
+        let frame = ws.next().await.unwrap();
+        assert_eq!(frame.payload().as_ref(), msg.as_bytes());
+    }
+}
+
+#[tokio::test]
+async fn completes_the_close_handshake() {
+    let addr = spawn_echo_server(Options::default()).await;
+    let mut ws = connect(addr, Options::default()).await.unwrap();
+
+    ws.send(Frame::close(CloseCode::Normal, b"bye"))
+        .await
+        .unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Close);
+    assert!(ws.next().await.is_none());
+}
+
+#[tokio::test]
+async fn one_connection_carries_concurrent_websockets() {
+    // Each connect() opens its own HTTP/2 connection, but they share one server task and
+    // must not interfere.
+    let addr = spawn_echo_server(Options::default()).await;
+
+    let mut sockets = Vec::new();
+    for _ in 0..4 {
+        sockets.push(connect(addr, Options::default()).await.unwrap());
+    }
+
+    for (i, ws) in sockets.iter_mut().enumerate() {
+        ws.send(Frame::text(format!("socket {i}"))).await.unwrap();
+    }
+
+    for (i, ws) in sockets.iter_mut().enumerate() {
+        let frame = ws.next().await.unwrap();
+        assert_eq!(frame.payload().as_ref(), format!("socket {i}").as_bytes());
+    }
+}
+
+#[tokio::test]
+async fn server_without_connect_protocol_is_reported_clearly() {
+    // Same server, but never advertising SETTINGS_ENABLE_CONNECT_PROTOCOL.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let service = service_fn(|req| handle(req, Options::default()));
+                let _ = http2::Builder::new(TokioExecutor::new())
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    let err = match connect(addr, Options::default()).await {
+        Ok(_) => panic!("handshake unexpectedly succeeded without extended CONNECT support"),
+        Err(err) => err,
+    };
+
+    assert!(
+        err.is_handshake_error(),
+        "expected a handshake error, got {err:?}"
+    );
+}
+
+#[tokio::test]
+async fn fragmented_message_is_reassembled() {
+    let addr = spawn_echo_server(Options::default()).await;
+    let ws = connect(addr, Options::default()).await.unwrap();
+    let mut streaming = ws.into_streaming();
+
+    streaming
+        .send(Frame::text("first ").with_fin(false))
+        .await
+        .unwrap();
+    streaming
+        .send(Frame::continuation("second").with_fin(true))
+        .await
+        .unwrap();
+
+    // The server reassembles, so what comes back is one unfragmented message.
+    let mut received = Vec::new();
+    while let Some(frame) = streaming.next().await {
+        received.extend_from_slice(frame.payload());
+        if frame.is_fin() {
+            break;
+        }
+    }
+
+    assert_eq!(received, b"first second");
+}

--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -269,18 +269,20 @@ async fn http1_version_uses_the_upgrade_handshake() {
 }
 
 #[tokio::test]
-async fn auto_over_plaintext_falls_back_to_http1() {
-    // Plaintext has no ALPN to negotiate with, so Auto must not assume HTTP/2 prior
-    // knowledge; it has to work against an ordinary HTTP/1.1 server.
+async fn the_default_version_is_http1() {
+    // Selecting a version is opt-in, and the default must not drag an existing caller
+    // onto the RFC 8441 path.
+    assert_eq!(HttpVersion::default(), HttpVersion::Http1);
+
     let addr = spawn_http1_echo_server().await;
-    let mut ws = connect_with(addr, Options::default(), HttpVersion::Auto)
+    let mut ws = connect_with(addr, Options::default(), HttpVersion::default())
         .await
         .unwrap();
 
-    ws.send(Frame::text("negotiated down")).await.unwrap();
+    ws.send(Frame::text("default is 6455")).await.unwrap();
 
     let frame = ws.next().await.unwrap();
-    assert_eq!(frame.payload().as_ref(), b"negotiated down");
+    assert_eq!(frame.payload().as_ref(), b"default is 6455");
 }
 
 #[tokio::test]

--- a/tests/http2.rs
+++ b/tests/http2.rs
@@ -4,7 +4,8 @@
 //! yawc's HTTP/2 handshake. Everything runs over plaintext TCP using HTTP/2 prior
 //! knowledge so the tests do not need certificates.
 
-#![cfg(feature = "http2")]
+// The wasm build compiles integration tests too, and none of this exists there.
+#![cfg(all(feature = "http2", not(target_arch = "wasm32")))]
 
 use std::{convert::Infallible, net::SocketAddr};
 

--- a/tests/http2_axum.rs
+++ b/tests/http2_axum.rs
@@ -4,7 +4,8 @@
 //! through hyper's HTTP/2 builder directly. Everything runs over plaintext with HTTP/2
 //! prior knowledge, so no certificates are needed.
 
-#![cfg(all(feature = "http2", feature = "axum"))]
+// The wasm build compiles integration tests too, and none of this exists there.
+#![cfg(all(feature = "http2", feature = "axum", not(target_arch = "wasm32")))]
 
 use std::net::SocketAddr;
 

--- a/tests/http2_axum.rs
+++ b/tests/http2_axum.rs
@@ -1,0 +1,122 @@
+//! The axum `IncomingUpgrade` extractor over HTTP/2 (RFC 8441).
+//!
+//! `axum::serve` does not expose `enable_connect_protocol()`, so the router is served
+//! through hyper's HTTP/2 builder directly. Everything runs over plaintext with HTTP/2
+//! prior knowledge, so no certificates are needed.
+
+#![cfg(all(feature = "http2", feature = "axum"))]
+
+use std::net::SocketAddr;
+
+use axum::{response::IntoResponse, routing::any, Router};
+use futures::{SinkExt, StreamExt};
+use hyper::server::conn::http2;
+use hyper_util::{
+    rt::{TokioExecutor, TokioIo},
+    service::TowerToHyperService,
+};
+use tokio::net::TcpListener;
+use yawc::{frame::OpCode, Frame, HttpVersion, HttpWebSocket, IncomingUpgrade, Options, WebSocket};
+
+/// Echoes data frames back to the client.
+async fn ws_handler(ws: IncomingUpgrade) -> impl IntoResponse {
+    let (response, fut) = ws
+        .upgrade(Options::default().with_balanced_compression())
+        .unwrap();
+
+    tokio::spawn(async move {
+        let mut ws = fut.await.unwrap();
+        while let Some(frame) = ws.next().await {
+            if matches!(frame.opcode(), OpCode::Text | OpCode::Binary)
+                && ws.send(frame).await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    response
+}
+
+/// Serves an axum router over HTTP/2 with extended CONNECT enabled.
+async fn spawn_axum_server() -> SocketAddr {
+    // `any` rather than `get`: an RFC 8441 handshake arrives as CONNECT, so a
+    // GET-only route would never match it.
+    let app = Router::new().route("/chat", any(ws_handler));
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            let service = TowerToHyperService::new(app.clone());
+
+            tokio::spawn(async move {
+                let _ = http2::Builder::new(TokioExecutor::new())
+                    .enable_connect_protocol()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+async fn connect(addr: SocketAddr) -> HttpWebSocket {
+    WebSocket::connect(format!("ws://{addr}/chat").parse().unwrap())
+        .http_version(HttpVersion::Http2)
+        .with_options(Options::default().with_balanced_compression())
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn extractor_accepts_extended_connect() {
+    let addr = spawn_axum_server().await;
+    let mut ws = connect(addr).await;
+
+    ws.send(Frame::text("hello axum")).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Text);
+    assert_eq!(frame.payload().as_ref(), b"hello axum");
+}
+
+#[tokio::test]
+async fn extractor_negotiates_compression_over_http2() {
+    let addr = spawn_axum_server().await;
+    let mut ws = connect(addr).await;
+
+    let payload = "axum deflate ".repeat(2048);
+    ws.send(Frame::text(payload.clone())).await.unwrap();
+
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.payload().as_ref(), payload.as_bytes());
+}
+
+#[tokio::test]
+async fn extractor_rejects_a_plain_request_on_the_same_route() {
+    // The route accepts any method, so an ordinary HTTP/2 GET reaches the extractor. It
+    // is not an extended CONNECT and carries no Sec-WebSocket-Key, so it must be turned
+    // away rather than upgraded.
+    let addr = spawn_axum_server().await;
+
+    let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+    let (mut sender, conn) =
+        hyper::client::conn::http2::handshake(TokioExecutor::new(), TokioIo::new(stream))
+            .await
+            .unwrap();
+
+    tokio::spawn(conn);
+
+    let request = hyper::Request::builder()
+        .method(hyper::Method::GET)
+        .uri(format!("http://{addr}/chat"))
+        .body(http_body_util::Empty::<bytes::Bytes>::new())
+        .unwrap();
+
+    let response = sender.send_request(request).await.unwrap();
+
+    assert_eq!(response.status(), hyper::StatusCode::BAD_REQUEST);
+}


### PR DESCRIPTION
Closes #39 for the HTTP/2 half. HTTP/3 (RFC 9220) is deliberately out of scope, see the end.

## Why this is smaller than it looks

RFC 8441 replaces only the handshake. A WebSocket is opened with an extended CONNECT on a single HTTP/2 stream, and the frames that follow are the same RFC 6455 frames, masking included. `permessage-deflate` still applies, since HPACK compresses headers rather than payloads.

The part that looked expensive, adapting h2's flow-controlled `SendStream`/`RecvStream` to a byte stream, is already done upstream: hyper implements the CONNECT upgrade on both client and server and hands back an `Upgraded` that is `AsyncRead + AsyncWrite`. `UpgradeFut` and `WebSocket::new` were already transport-agnostic, and `HttpStream::Hyper` already wraps exactly that type.

So this adds handshake code and no transport code. `codec.rs`, `frame.rs`, `compression.rs` and `mask.rs` are untouched. hyper was already a dependency; this enables its `http2` feature.

## Protocol differences handled

| | HTTP/1.1 | HTTP/2 |
|---|---|---|
| Request | `GET` + `Upgrade`/`Connection` | `CONNECT` + `:protocol = websocket` |
| `Sec-WebSocket-Key` | required | forbidden (RFC 8441 §5) |
| Success status | `101` | `200` |
| `Sec-WebSocket-Accept` | required | absent |
| `Sec-WebSocket-Version: 13` | required | required |
| `Sec-WebSocket-Extensions` | as usual | as usual |

## API

Behind a new `http2` feature, off by default.

**Client.** HTTP/1.1 stays the default, so existing code is untouched:

```rust
let ws = WebSocket::connect("wss://example.com/chat".parse()?)
    .http_version(HttpVersion::Http2)
    .await?;
```

`HttpVersion` is `Http1` (default) and `Http2`. There is deliberately **no automatic negotiation** — see the next section for why. `http_version` returns `WebSocketBuilder<HttpStream>` rather than a second builder type: the builder gained a type parameter defaulting to the socket it already returned, so `WebSocketBuilder` in a type position still resolves exactly as before and the builder methods are written once.

**Server.** `upgrade` and `upgrade_with_options` detect extended CONNECT and answer `200` with no key exchange, so **a single handler serves both HTTP versions** with no caller changes. Same for the axum `IncomingUpgrade` extractor (route it with `any(...)`, since the handshake arrives as CONNECT). The one thing callers must do is set `enable_connect_protocol()` on hyper's HTTP/2 server builder, which is what advertises `SETTINGS_ENABLE_CONNECT_PROTOCOL`.

**Also added, unflagged:** `WebSocket::from_stream` and `from_stream_with_extensions`, for wrapping a stream handshaked elsewhere.

## Why HTTP/2 is opt-in and does not fall back

An earlier revision had an `Auto` mode that negotiated over ALPN. Testing against real endpoints showed why that cannot work: ALPN answers the wrong question. Agreeing on `h2` says the peer speaks HTTP/2, not that it implements RFC 8441, and the two rarely coincide.

Probed seven public endpoints (echo.websocket.org, Binance, Coinbase, Kraken, Bybit, OKX, Deribit). **All seven negotiate `h2`. None accept extended CONNECT.** So `Auto` guessed wrong essentially every time, and a fallback to rescue it spent a full TCP and TLS handshake before doing what HTTP/1.1 would have done immediately.

`Auto` is gone. A caller who knows their server supports RFC 8441 does not need a guess, and one who does not should stay on HTTP/1.1. Choosing `Http2` against a peer without support now fails with `ExtendedConnectNotSupported` rather than silently downgrading. Callers who want fallback can write it in four lines with `is_handshake_error()`, where the cost of the second connection is visible.

## Error reporting

hyper does not expose the peer's `SETTINGS_ENABLE_CONNECT_PROTOCOL` to the client, so support cannot be checked up front. A server without it treats `:protocol` as malformed and resets the stream with `PROTOCOL_ERROR`; that reason is mapped to `ExtendedConnectNotSupported`. `h2` is a direct optional dependency solely to classify it.

## Shared rather than duplicated

Review pointed out the HTTP/2 path was re-implementing what already existed. Addressed:

- `handshake_http1_upgraded` was a near-copy of `handshake_with_request`. They differ only in what they do with hyper's upgraded stream; everything before that is now `http1_upgrade`, called by both.
- The HTTP/2 server upgrade was a second copy of the version check, extension negotiation and `UpgradeFut` construction. `upgrade_with_options` now picks only the response's opening line per protocol and runs one body, so `http2::upgrade` is deleted. That also made `MissingConnectProtocol` unreachable, so it is gone too.
- Reading `Sec-WebSocket-Extensions` appeared six times, and "negotiate only when both sides offer" three times. Now `WebSocketExtensions::from_headers` and `::agree`.
- Two extended-CONNECT predicates collapsed into one.

**That work found a real bug.** The original handshake cfg-gates its connection task between `tokio::spawn` and `smol::spawn`. The copied HTTP/1.1 path and the HTTP/2 handshake both called `tokio::spawn` unconditionally, so under `--features smol,http2` they would panic with no tokio runtime running. Both now go through `spawn_connection`.

What remains in `http2.rs` is 402 lines, half of them tests: building the extended CONNECT request, checking a 200 response, classifying the stream reset, and recognising the request shape. No function body in it is more than 60% similar to anything in `mod.rs`.

## Testing

Unit tests for request and response construction, plus integration tests driving a real hyper HTTP/2 server over plaintext prior knowledge (no TLS, so no certificates):

- echo of text and binary; 100 messages in sequence
- a 256 KiB payload, well past the 16 KiB default HTTP/2 frame size, so it spans multiple DATA frames
- `permessage-deflate` end to end; fragmentation; ping/pong; the close handshake
- several concurrent connections
- a server *without* `enable_connect_protocol()`, asserting a clean handshake error
- `HttpVersion::Http1` against an HTTP/1.1 server, and `Http2` against one, asserting it fails rather than hanging

`tests/from_stream.rs` covers the new constructor, including asserting against raw bytes that `Role` drives masking. `tests/axum_upgrade.rs` pins the HTTP/1.1 response against the canonical RFC 6455 vector (`dGhlIHNhbXBsZSBub25jZQ==` → `s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`) and runs **without** `http2`, matching how autobahn builds the server.

CI gained `Test axum` and `Test http2` steps — the existing default and zlib runs enable neither, so none of this would otherwise have run there. Autobahn stays HTTP/1.1.

The examples talk to each other for real:

```
$ cargo run --features http2 --example http2_server
$ cargo run --features http2 --example http2_client
connected
sent:  hello 0
recv:  hello 0
```

## Not included

HTTP/3 and RFC 9220: it needs quinn plus the `h3` crate, which is not 1.0. The delta from 8441 is small once the handshake is decoupled like this. Also out of scope: the reqwest path, wasm, autobahn over HTTP/2, browser interop.

## Worth knowing before merging

Client-side RFC 8441 has almost no reach today: zero of seven major endpoints support it. The realistic use is **server-side**, behind an h2-to-origin proxy (Envoy does this; nginx does not proxy 8441 upstream at all). The feature is off by default and adds nothing to the default build, and the default client path is unchanged and live-verified.
