### PR TITLE
Add SOCKS5 proxy support to the client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### SOCKS5 proxy support (RFC 1928)
+
+- **`WebSocket::connect(url).with_proxy(proxy)`**: Dials a SOCKS5 proxy and asks it to
+  tunnel to the WebSocket host. Everything above the tunnel is unchanged, so a `wss://`
+  connection still negotiates TLS with the target and the proxy sees only ciphertext.
+  Works with the HTTP/1.1 and the HTTP/2 handshake alike.
+- **`Proxy::socks5(url)`**: Builds the proxy from a URL. `socks5h://` sends the target
+  hostname for the proxy to resolve, `socks5://` resolves it locally and sends an
+  address, and `user:pass@` in the URL turns on RFC 1929 username/password
+  authentication. A URL without a port uses 1080.
+- **`WebSocketError::Socks5`**: A refusal from the proxy arrives as a typed
+  `Socks5Error`, with the RFC 1928 reply code in `ReplyCode`, rather than as an opaque
+  I/O error.
+- No new feature flag and no new runtime dependency: the handshake is part of the native
+  client.
+
 #### WebSockets over HTTP/2 (RFC 8441)
 
 - **New `http2` feature**: Carries WebSocket connections over a single HTTP/2 stream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -172,6 +172,7 @@ sha1 = "0.10"
 
 # Utilities
 nom = "8"
+percent-encoding = "2"
 pin-project = "1"
 log = "0.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,10 @@ test = false
 name = "proxy"
 test = false
 
+[[example]]
+name = "socks5"
+test = false
+
 # ==============================================================================
 # Common dependencies (shared across all targets)
 # ==============================================================================

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ yawc stands apart as the **most flexible and feature-complete WebSocket library*
 - **Autobahn Test Suite**: Passes all test cases for both client and server modes
 - **WebAssembly Support**: Works seamlessly in WASM environments for browser-based applications (both text and binary modes supported)
 - **HTTP/2 (RFC 8441)**: Optional extended CONNECT handshake for client and server, behind the `http2` feature
+- **SOCKS5 Proxy**: Client connections can be dialled through a SOCKS5 proxy (RFC 1928), with username/password authentication
 
 ## About compression
 
@@ -144,6 +145,28 @@ yawc = { version = "0.3" }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros"] }
 ```
+
+### Connecting Through a SOCKS5 Proxy
+
+```rust
+use yawc::{Proxy, Result, WebSocket};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // socks5h:// leaves the hostname for the proxy to resolve; socks5:// resolves it
+    // locally and sends an address. Credentials are optional.
+    let proxy = Proxy::socks5("socks5h://user:pass@127.0.0.1:1080".parse()?)?;
+
+    let ws = WebSocket::connect("wss://echo.websocket.org".parse()?)
+        .with_proxy(proxy)
+        .await?;
+
+    Ok(())
+}
+```
+
+TLS runs end to end through the tunnel, so a `wss://` connection is negotiated with the
+target and the proxy only ever sees ciphertext.
 
 ### Server Example
 

--- a/examples/socks5.rs
+++ b/examples/socks5.rs
@@ -1,0 +1,37 @@
+//! Connects through a SOCKS5 proxy and echoes one message.
+//!
+//! Usage: cargo run --example socks5 -- <proxy-url> [ws-url]
+//!
+//! The proxy URL is `socks5h://[user:pass@]host:port`, or `socks5://` to resolve the
+//! target locally instead of leaving it to the proxy.
+
+use futures::{SinkExt, StreamExt};
+use yawc::{Frame, Proxy, WebSocket};
+
+#[tokio::main]
+async fn main() -> yawc::Result<()> {
+    simple_logger::init_with_level(log::Level::Info).expect("log");
+
+    let mut args = std::env::args().skip(1);
+    let proxy_url = args.next().expect("usage: socks5 <proxy-url> [ws-url]");
+    let ws_url = args
+        .next()
+        .unwrap_or_else(|| "wss://echo.websocket.org".to_string());
+
+    let proxy = Proxy::socks5(proxy_url.parse()?)?;
+    log::info!("connecting to {ws_url} through {proxy:?}");
+
+    // TLS is negotiated with the target through the tunnel, so the proxy sees only
+    // ciphertext for a wss:// URL.
+    let mut ws = WebSocket::connect(ws_url.parse()?)
+        .with_proxy(proxy)
+        .await?;
+
+    ws.send(Frame::text("hello through the proxy")).await?;
+
+    while let Some(frame) = ws.next().await {
+        log::info!("received {:?}: {}", frame.opcode(), frame.as_str());
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,27 @@
 //! }
 //! ```
 //!
+//! # SOCKS5 Proxy
+//!
+//! A client connection can be dialled through a SOCKS5 proxy (RFC 1928) by handing the
+//! builder a [`Proxy`]:
+//!
+//! ```no_run
+//! use yawc::{Proxy, WebSocket};
+//!
+//! # async fn example() -> yawc::Result<()> {
+//! let ws = WebSocket::connect("wss://echo.websocket.org".parse()?)
+//!     .with_proxy(Proxy::socks5("socks5h://user:pass@127.0.0.1:1080".parse()?)?)
+//!     .await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! `socks5h://` leaves the target hostname for the proxy to resolve, `socks5://` resolves
+//! it locally, and credentials in the URL turn on RFC 1929 username/password
+//! authentication. TLS runs end to end through the tunnel, so the proxy sees only
+//! ciphertext on a `wss://` connection.
+//!
 //! # Protocol Handling
 //!
 //! yawc automatically handles WebSocket control frames:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -248,6 +248,11 @@ pub enum WebSocketError {
     #[cfg(not(target_arch = "wasm32"))]
     CompressionNotSupported,
 
+    /// The SOCKS5 proxy refused or could not complete the connection.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[error(transparent)]
+    Socks5(#[from] Socks5Error),
+
     /// URL parsing error.
     #[error(transparent)]
     UrlParseError(#[from] url::ParseError),

--- a/src/native/builder.rs
+++ b/src/native/builder.rs
@@ -11,7 +11,7 @@ use futures::{future::BoxFuture, FutureExt};
 use tokio_rustls::TlsConnector;
 use url::Url;
 
-use super::{Options, WebSocket};
+use super::{Options, Proxy, WebSocket};
 use crate::{stream::MaybeTlsStream, Result};
 use tokio::net::TcpStream;
 
@@ -81,10 +81,11 @@ pub struct WebSocketBuilder<S = MaybeTlsStream<TcpStream>> {
 ///
 /// Holds all the configuration options needed to establish a WebSocket connection,
 /// including the target URL, TLS connector, connection options, and HTTP request builder.
-pub(super) struct WsBuilderOpts {
+pub(crate) struct WsBuilderOpts {
     pub(super) url: Url,
     pub(super) tcp_address: Option<SocketAddr>,
     pub(super) connector: Option<TlsConnector>,
+    pub(super) proxy: Option<Proxy>,
     pub(super) establish_options: Option<Options>,
     pub(super) http_builder: Option<HttpRequestBuilder>,
     #[cfg(feature = "http2")]
@@ -105,6 +106,7 @@ impl<S> WebSocketBuilder<S> {
                 url,
                 tcp_address: None,
                 connector: None,
+                proxy: None,
                 establish_options: None,
                 http_builder: None,
                 #[cfg(feature = "http2")]
@@ -150,6 +152,39 @@ impl<S> WebSocketBuilder<S> {
             unreachable!()
         };
         opts.tcp_address = Some(address);
+        self
+    }
+
+    /// Dials through a SOCKS5 proxy instead of connecting to the host directly.
+    ///
+    /// The proxy is asked to open a tunnel to the URL's host, and everything above that
+    /// runs through the tunnel unchanged, so a `wss://` connection still negotiates TLS
+    /// end to end and the proxy sees only ciphertext.
+    ///
+    /// # Parameters
+    /// - `proxy`: The proxy to dial through, from [`Proxy::socks5`]
+    ///
+    /// # Returns
+    /// The builder for method chaining
+    ///
+    /// # Example
+    /// ```no_run
+    /// use yawc::{Proxy, WebSocket};
+    ///
+    /// async fn connect() -> yawc::Result<()> {
+    ///     let ws = WebSocket::connect("wss://example.com/socket".parse()?)
+    ///         .with_proxy(Proxy::socks5("socks5h://127.0.0.1:1080".parse()?)?)
+    ///         .await?;
+    ///
+    ///     // Use WebSocket...
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn with_proxy(mut self, proxy: Proxy) -> Self {
+        let Some(opts) = &mut self.opts else {
+            unreachable!()
+        };
+        opts.proxy = Some(proxy);
         self
     }
 
@@ -321,14 +356,7 @@ impl Future for WebSocketBuilder<super::HttpStream> {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         if let Some(opts) = this.opts.take() {
-            let future = super::connect_versioned(
-                opts.url,
-                opts.tcp_address,
-                opts.connector,
-                opts.establish_options.unwrap_or_default(),
-                opts.http_builder.unwrap_or_else(HttpRequest::builder),
-                opts.version,
-            );
+            let future = super::connect_versioned(opts);
             this.future = Some(Box::pin(future));
         }
 
@@ -355,13 +383,7 @@ impl Future for WebSocketBuilder {
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.get_mut();
         if let Some(opts) = this.opts.take() {
-            let future = WebSocket::connect_priv(
-                opts.url,
-                opts.tcp_address,
-                opts.connector,
-                opts.establish_options.unwrap_or_default(),
-                opts.http_builder.unwrap_or_else(HttpRequest::builder),
-            );
+            let future = WebSocket::connect_priv(opts);
             this.future = Some(Box::pin(future));
         }
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -117,6 +117,7 @@ mod builder;
 #[cfg(feature = "http2")]
 pub mod http2;
 mod options;
+mod socks5;
 mod split;
 pub mod streaming;
 mod upgrade;
@@ -160,6 +161,7 @@ pub use builder::HttpVersion;
 pub use builder::{HttpRequest, HttpRequestBuilder, WebSocketBuilder};
 pub use frame::{Frame, OpCode};
 pub use options::{CompressionLevel, DeflateOptions, Fragmentation, Options};
+pub use socks5::{Proxy, Socks5Error};
 pub use split::{ReadHalf, WriteHalf};
 pub use upgrade::UpgradeFut;
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -161,7 +161,7 @@ pub use builder::HttpVersion;
 pub use builder::{HttpRequest, HttpRequestBuilder, WebSocketBuilder};
 pub use frame::{Frame, OpCode};
 pub use options::{CompressionLevel, DeflateOptions, Fragmentation, Options};
-pub use socks5::{Proxy, Socks5Error};
+pub use socks5::{Proxy, ReplyCode, Socks5Error};
 pub use split::{ReadHalf, WriteHalf};
 pub use upgrade::UpgradeFut;
 

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -138,7 +138,6 @@ use std::{
     collections::VecDeque,
     future::poll_fn,
     io,
-    net::SocketAddr,
     pin::{pin, Pin},
     str::FromStr,
     sync::Arc,
@@ -147,6 +146,7 @@ use std::{
 };
 use tokio::io::{AsyncRead, AsyncWrite};
 
+use builder::WsBuilderOpts;
 use codec::Codec;
 use compression::{CompressionConfig, Compressor, Decompressor, WebSocketExtensions};
 use futures::{task::AtomicWaker, SinkExt};
@@ -727,37 +727,16 @@ impl WebSocket<MaybeTlsStream<TcpStream>> {
         WebSocketBuilder::new(url)
     }
 
-    pub(crate) async fn connect_priv(
-        url: Url,
-        tcp_address: Option<SocketAddr>,
-        connector: Option<TlsConnector>,
-        options: Options,
-        builder: HttpRequestBuilder,
-    ) -> Result<TcpWebSocket> {
-        let host = url.host().expect("hostname").to_string();
+    pub(crate) async fn connect_priv(mut opts: WsBuilderOpts) -> Result<TcpWebSocket> {
+        let options = opts.establish_options.take().unwrap_or_default();
+        let builder = opts
+            .http_builder
+            .take()
+            .unwrap_or_else(HttpRequest::builder);
 
-        let tcp_stream = if let Some(tcp_address) = tcp_address {
-            TcpStream::connect(tcp_address).await?
-        } else {
-            let port = url.port_or_known_default().expect("port");
-            TcpStream::connect(format!("{host}:{port}")).await?
-        };
+        let stream = connect_stream(&opts, &options, HTTP1_ALPN).await?;
 
-        let _ = tcp_stream.set_nodelay(options.no_delay);
-
-        let stream = match url.scheme() {
-            "ws" => MaybeTlsStream::Plain(tcp_stream),
-            "wss" => {
-                let connector = connector.unwrap_or_else(tls_connector);
-                let domain = ServerName::try_from(host)
-                    .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))?;
-
-                MaybeTlsStream::Tls(connector.connect(domain, tcp_stream).await?)
-            }
-            _ => return Err(WebSocketError::InvalidHttpScheme),
-        };
-
-        WebSocket::handshake_with_request(url, stream, options, builder).await
+        WebSocket::handshake_with_request(opts.url, stream, options, builder).await
     }
 }
 
@@ -1450,46 +1429,82 @@ fn generate_key() -> String {
 /// because an HTTP/2 WebSocket is one stream of a multiplexed connection and there is no
 /// socket to hand back. Both versions therefore produce the same type.
 #[cfg(feature = "http2")]
-async fn connect_versioned(
-    url: Url,
-    tcp_address: Option<SocketAddr>,
-    connector: Option<TlsConnector>,
-    options: Options,
-    builder: HttpRequestBuilder,
-    version: HttpVersion,
-) -> Result<HttpWebSocket> {
-    let host = url.host().expect("hostname").to_string();
-
-    let tcp_stream = if let Some(tcp_address) = tcp_address {
-        TcpStream::connect(tcp_address).await?
-    } else {
-        let port = url.port_or_known_default().expect("port");
-        TcpStream::connect(format!("{host}:{port}")).await?
-    };
-
-    let _ = tcp_stream.set_nodelay(options.no_delay);
+async fn connect_versioned(mut opts: WsBuilderOpts) -> Result<HttpWebSocket> {
+    let options = opts.establish_options.take().unwrap_or_default();
+    let builder = opts
+        .http_builder
+        .take()
+        .unwrap_or_else(HttpRequest::builder);
+    let version = opts.version;
 
     // Over plaintext there is no ALPN to negotiate with, so HTTP/2 means prior knowledge.
-    let stream = match url.scheme() {
-        "ws" => MaybeTlsStream::Plain(tcp_stream),
-        "wss" => {
-            let connector = connector.unwrap_or_else(|| tls_connector_with_alpn(alpn_for(version)));
-            let domain = ServerName::try_from(host)
-                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))?;
-
-            MaybeTlsStream::Tls(connector.connect(domain, tcp_stream).await?)
-        }
-        _ => return Err(WebSocketError::InvalidHttpScheme),
-    };
+    let stream = connect_stream(&opts, &options, alpn_for(version)).await?;
 
     // Whatever the caller asked for is what runs. There is nothing to negotiate: a peer
     // that speaks h2 usually still wants WebSockets over HTTP/1.1, so picking HTTP/2 on
     // the strength of ALPN alone would be wrong more often than right. That is why the
     // HTTP/2 handshake is opt-in and why it fails here rather than quietly downgrading.
     match version {
-        HttpVersion::Http2 => http2::handshake(url, stream, options, builder).await,
-        HttpVersion::Http1 => handshake_http1_upgraded(url, stream, options, builder).await,
+        HttpVersion::Http2 => http2::handshake(opts.url, stream, options, builder).await,
+        HttpVersion::Http1 => handshake_http1_upgraded(opts.url, stream, options, builder).await,
     }
+}
+
+#[cfg_attr(not(feature = "http2"), allow(dead_code))]
+/// Opens the transport the handshake runs over.
+///
+/// This is the whole of what the two client entry points share: a TCP connection, dialled
+/// through a SOCKS5 proxy when one is configured, wrapped in TLS for a `wss://` URL. The
+/// tunnel is transparent by then, so TLS is negotiated with the target either way and the
+/// proxy never sees inside it.
+async fn connect_stream(
+    opts: &WsBuilderOpts,
+    options: &Options,
+    alpn: &[&[u8]],
+) -> Result<MaybeTlsStream<TcpStream>> {
+    let tcp_stream = dial(opts).await?;
+    let _ = tcp_stream.set_nodelay(options.no_delay);
+
+    match opts.url.scheme() {
+        "ws" => Ok(MaybeTlsStream::Plain(tcp_stream)),
+        "wss" => {
+            let host = opts.url.host().expect("hostname").to_string();
+            let connector = opts
+                .connector
+                .clone()
+                .unwrap_or_else(|| tls_connector_with_alpn(alpn));
+            let domain = ServerName::try_from(host)
+                .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dnsname"))?;
+
+            Ok(MaybeTlsStream::Tls(
+                connector.connect(domain, tcp_stream).await?,
+            ))
+        }
+        _ => Err(WebSocketError::InvalidHttpScheme),
+    }
+}
+
+/// Opens the TCP connection, either straight to the target or to a SOCKS5 proxy that is
+/// then asked to tunnel to it.
+async fn dial(opts: &WsBuilderOpts) -> Result<TcpStream> {
+    let Some(proxy) = opts.proxy.as_ref() else {
+        let stream = match opts.tcp_address {
+            Some(address) => TcpStream::connect(address).await?,
+            None => {
+                let host = opts.url.host().expect("hostname").to_string();
+                let port = opts.url.port_or_known_default().expect("port");
+                TcpStream::connect(format!("{host}:{port}")).await?
+            }
+        };
+
+        return Ok(stream);
+    };
+
+    let target = proxy.target(&opts.url, opts.tcp_address).await?;
+    let mut stream = proxy.dial().await?;
+    socks5::connect(&mut stream, proxy, &target).await?;
+
+    Ok(stream)
 }
 
 /// Runs the HTTP/1.1 handshake but keeps hyper's upgraded stream instead of downcasting.
@@ -1519,20 +1534,18 @@ where
 
 /// Returns the ALPN protocols to offer for a given HTTP version preference.
 #[cfg(feature = "http2")]
-fn alpn_for(version: HttpVersion) -> Vec<Vec<u8>> {
+fn alpn_for(version: HttpVersion) -> &'static [&'static [u8]] {
     match version {
-        HttpVersion::Http1 => vec![b"http/1.1".to_vec()],
-        HttpVersion::Http2 => vec![b"h2".to_vec()],
+        HttpVersion::Http1 => HTTP1_ALPN,
+        HttpVersion::Http2 => &[b"h2"],
     }
 }
 
-/// Creates a TLS connector with root certificates for secure WebSocket connections.
-fn tls_connector() -> TlsConnector {
-    tls_connector_with_alpn(vec![b"http/1.1".to_vec()])
-}
+/// The only ALPN protocol the RFC 6455 handshake can run over.
+const HTTP1_ALPN: &[&[u8]] = &[b"http/1.1"];
 
 /// Creates a TLS connector offering the given ALPN protocols.
-fn tls_connector_with_alpn(alpn_protocols: Vec<Vec<u8>>) -> TlsConnector {
+fn tls_connector_with_alpn(alpn_protocols: &[&[u8]]) -> TlsConnector {
     let mut root_cert_store = rustls::RootCertStore::empty();
     root_cert_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| TrustAnchor {
         subject: ta.subject.clone(),
@@ -1569,7 +1582,7 @@ Either:
         .expect("versions")
         .with_root_certificates(root_cert_store)
         .with_no_client_auth();
-    config.alpn_protocols = alpn_protocols;
+    config.alpn_protocols = alpn_protocols.iter().map(|proto| proto.to_vec()).collect();
 
     TlsConnector::from(Arc::new(config))
 }

--- a/src/native/mod.rs
+++ b/src/native/mod.rs
@@ -180,6 +180,9 @@ pub type HttpWebSocket = WebSocket<HttpStream>;
 #[cfg(feature = "axum")]
 pub use upgrade::IncomingUpgrade;
 
+/// The only ALPN protocol the RFC 6455 handshake can run over.
+const HTTP1_ALPN: &[&[u8]] = &[b"http/1.1"];
+
 /// The maximum allowed payload size for reading, set to 1 MiB.
 ///
 /// Frames with a payload size larger than this limit will be rejected to ensure memory safety
@@ -1540,9 +1543,6 @@ fn alpn_for(version: HttpVersion) -> &'static [&'static [u8]] {
         HttpVersion::Http2 => &[b"h2"],
     }
 }
-
-/// The only ALPN protocol the RFC 6455 handshake can run over.
-const HTTP1_ALPN: &[&[u8]] = &[b"http/1.1"];
 
 /// Creates a TLS connector offering the given ALPN protocols.
 fn tls_connector_with_alpn(alpn_protocols: &[&[u8]]) -> TlsConnector {

--- a/src/native/socks5.rs
+++ b/src/native/socks5.rs
@@ -20,6 +20,15 @@ use url::{Host, Url};
 
 use crate::Result;
 
+/// The protocol version this module speaks.
+const VERSION: u8 = 5;
+
+/// `CONNECT`, the only command a WebSocket client needs.
+const CMD_CONNECT: u8 = 1;
+
+/// The username/password sub-negotiation is versioned separately (RFC 1929).
+const AUTH_VERSION: u8 = 1;
+
 /// The port a SOCKS5 proxy is assumed to listen on when the URL does not say.
 const DEFAULT_PORT: u16 = 1080;
 
@@ -27,6 +36,57 @@ const DEFAULT_PORT: u16 = 1080;
 /// request gives the hostname one too.
 const MAX_CREDENTIAL_LEN: usize = 255;
 const MAX_HOSTNAME_LEN: usize = 255;
+
+/// An authentication method, as offered in the greeting and picked by the proxy.
+///
+/// Only the two this client can actually run are named; anything else the proxy answers
+/// with is reported as unsupported rather than mapped to a variant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Method {
+    /// No authentication.
+    None = 0x00,
+    /// Username and password, as defined by RFC 1929.
+    UserPass = 0x02,
+    /// The proxy's answer when it accepts none of the offered methods.
+    Unacceptable = 0xFF,
+}
+
+impl Method {
+    /// Reads back a method the proxy selected, if it is one this client offered.
+    fn from_code(code: u8) -> Option<Self> {
+        match code {
+            0x00 => Some(Self::None),
+            0x02 => Some(Self::UserPass),
+            0xFF => Some(Self::Unacceptable),
+            _ => None,
+        }
+    }
+}
+
+/// The address types a request and a reply can carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum AddressType {
+    /// Four bytes of IPv4 address.
+    Ipv4 = 1,
+    /// A length byte followed by that many bytes of hostname.
+    Domain = 3,
+    /// Sixteen bytes of IPv6 address.
+    Ipv6 = 4,
+}
+
+impl AddressType {
+    /// Reads back an address type, if it is one the protocol defines.
+    fn from_code(code: u8) -> Option<Self> {
+        match code {
+            1 => Some(Self::Ipv4),
+            3 => Some(Self::Domain),
+            4 => Some(Self::Ipv6),
+            _ => None,
+        }
+    }
+}
 
 /// A SOCKS5 proxy to dial through.
 ///
@@ -133,23 +193,6 @@ fn decode(value: &str) -> Result<String> {
         .map_err(|_| Socks5Error::InvalidCredentials.into())
 }
 
-/// The protocol version this module speaks.
-const VERSION: u8 = 5;
-
-/// `CONNECT`, the only command a WebSocket client needs.
-const CMD_CONNECT: u8 = 1;
-
-const METHOD_NONE: u8 = 0x00;
-const METHOD_USERPASS: u8 = 0x02;
-const METHOD_UNACCEPTABLE: u8 = 0xFF;
-
-/// The username/password sub-negotiation is versioned separately (RFC 1929).
-const AUTH_VERSION: u8 = 1;
-
-const ATYP_IPV4: u8 = 1;
-const ATYP_DOMAIN: u8 = 3;
-const ATYP_IPV6: u8 = 4;
-
 /// Where the proxy is asked to connect to.
 ///
 /// A hostname is what `socks5h://` sends, leaving resolution to the proxy. An address is
@@ -188,8 +231,8 @@ where
     S: AsyncRead + AsyncWrite + Unpin,
 {
     let greeting: &[u8] = match proxy.auth {
-        Some(_) => &[VERSION, 2, METHOD_NONE, METHOD_USERPASS],
-        None => &[VERSION, 1, METHOD_NONE],
+        Some(_) => &[VERSION, 2, Method::None as u8, Method::UserPass as u8],
+        None => &[VERSION, 1, Method::None as u8],
     };
     stream.write_all(greeting).await?;
     stream.flush().await?;
@@ -201,11 +244,13 @@ where
         return Err(Socks5Error::UnsupportedVersion(chosen[0]).into());
     }
 
-    match (chosen[1], proxy.auth.as_ref()) {
-        (METHOD_NONE, _) => Ok(()),
-        (METHOD_USERPASS, Some(auth)) => authenticate(stream, auth).await,
-        (METHOD_UNACCEPTABLE, _) => Err(Socks5Error::NoAcceptableAuth.into()),
-        (method, _) => Err(Socks5Error::UnsupportedMethod(method).into()),
+    match (Method::from_code(chosen[1]), proxy.auth.as_ref()) {
+        (Some(Method::None), _) => Ok(()),
+        (Some(Method::UserPass), Some(auth)) => authenticate(stream, auth).await,
+        (Some(Method::Unacceptable), _) => Err(Socks5Error::NoAcceptableAuth.into()),
+        // Either a method that was never offered, or username/password without any
+        // credentials to send.
+        _ => Err(Socks5Error::UnsupportedMethod(chosen[1]).into()),
     }
 }
 
@@ -249,18 +294,18 @@ where
 
     match target {
         Target::Domain { host, port } => {
-            request.push(ATYP_DOMAIN);
+            request.push(AddressType::Domain as u8);
             request.push(host.len() as u8);
             request.extend_from_slice(host.as_bytes());
             request.extend_from_slice(&port.to_be_bytes());
         }
         Target::Addr(SocketAddr::V4(addr)) => {
-            request.push(ATYP_IPV4);
+            request.push(AddressType::Ipv4 as u8);
             request.extend_from_slice(&addr.ip().octets());
             request.extend_from_slice(&addr.port().to_be_bytes());
         }
         Target::Addr(SocketAddr::V6(addr)) => {
-            request.push(ATYP_IPV6);
+            request.push(AddressType::Ipv6 as u8);
             request.extend_from_slice(&addr.ip().octets());
             request.extend_from_slice(&addr.port().to_be_bytes());
         }
@@ -288,15 +333,15 @@ where
         return Err(Socks5Error::Rejected(ReplyCode::from(head[1])).into());
     }
 
-    let address_len = match head[3] {
-        ATYP_IPV4 => 4,
-        ATYP_IPV6 => 16,
-        ATYP_DOMAIN => {
+    let address_len = match AddressType::from_code(head[3]) {
+        Some(AddressType::Ipv4) => 4,
+        Some(AddressType::Ipv6) => 16,
+        Some(AddressType::Domain) => {
             let mut len = [0; 1];
             stream.read_exact(&mut len).await?;
             usize::from(len[0])
         }
-        atyp => return Err(Socks5Error::InvalidAddressType(atyp).into()),
+        None => return Err(Socks5Error::InvalidAddressType(head[3]).into()),
     };
 
     // The bound address and port are of no use to a client that only wanted a tunnel, but

--- a/src/native/socks5.rs
+++ b/src/native/socks5.rs
@@ -5,17 +5,25 @@
 //! Everything above that, TLS included, then runs end to end through the tunnel, so the
 //! proxy sees only ciphertext for a `wss://` URL.
 
-use std::{fmt, net::IpAddr};
+use std::{
+    fmt,
+    net::{IpAddr, SocketAddr},
+};
 
 use percent_encoding::percent_decode_str;
 use thiserror::Error;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use url::{Host, Url};
+
+use crate::Result;
 
 /// The port a SOCKS5 proxy is assumed to listen on when the URL does not say.
 const DEFAULT_PORT: u16 = 1080;
 
-/// RFC 1929 gives the username and password a single length byte each.
+/// RFC 1929 gives the username and password a single length byte each, and a `CONNECT`
+/// request gives the hostname one too.
 const MAX_CREDENTIAL_LEN: usize = 255;
+const MAX_HOSTNAME_LEN: usize = 255;
 
 /// A SOCKS5 proxy to dial through.
 ///
@@ -69,11 +77,11 @@ impl Proxy {
     /// Credentials come from the URL's userinfo and are percent-decoded, so a password
     /// containing `@` or `:` can be written as `%40` and `%3A`. A URL without a port uses
     /// 1080.
-    pub fn socks5(url: Url) -> Result<Self, Socks5Error> {
+    pub fn socks5(url: Url) -> Result<Self> {
         let remote_dns = match url.scheme() {
             "socks5" => false,
             "socks5h" => true,
-            scheme => return Err(Socks5Error::UnsupportedScheme(scheme.to_string())),
+            scheme => return Err(Socks5Error::UnsupportedScheme(scheme.to_string()).into()),
         };
 
         let host = match url.host() {
@@ -86,7 +94,7 @@ impl Proxy {
             },
             Some(Host::Ipv4(ip)) => Host::Ipv4(ip),
             Some(Host::Ipv6(ip)) => Host::Ipv6(ip),
-            None => return Err(Socks5Error::MissingHost),
+            None => return Err(Socks5Error::MissingHost.into()),
         };
 
         let auth = match decode(url.username())? {
@@ -101,7 +109,7 @@ impl Proxy {
             if auth.username.len() > MAX_CREDENTIAL_LEN
                 || auth.password.0.len() > MAX_CREDENTIAL_LEN
             {
-                return Err(Socks5Error::CredentialsTooLong);
+                return Err(Socks5Error::CredentialsTooLong.into());
             }
         }
 
@@ -115,11 +123,240 @@ impl Proxy {
 }
 
 /// Percent-decodes one half of a URL's userinfo.
-fn decode(value: &str) -> Result<String, Socks5Error> {
+fn decode(value: &str) -> Result<String> {
     percent_decode_str(value)
         .decode_utf8()
         .map(|decoded| decoded.into_owned())
-        .map_err(|_| Socks5Error::InvalidCredentials)
+        .map_err(|_| Socks5Error::InvalidCredentials.into())
+}
+
+/// The protocol version this module speaks.
+const VERSION: u8 = 5;
+
+/// `CONNECT`, the only command a WebSocket client needs.
+const CMD_CONNECT: u8 = 1;
+
+const METHOD_NONE: u8 = 0x00;
+const METHOD_USERPASS: u8 = 0x02;
+const METHOD_UNACCEPTABLE: u8 = 0xFF;
+
+/// The username/password sub-negotiation is versioned separately (RFC 1929).
+const AUTH_VERSION: u8 = 1;
+
+const ATYP_IPV4: u8 = 1;
+const ATYP_DOMAIN: u8 = 3;
+const ATYP_IPV6: u8 = 4;
+
+/// Where the proxy is asked to connect to.
+///
+/// A hostname is what `socks5h://` sends, leaving resolution to the proxy. An address is
+/// what `socks5://` sends, and what a caller who pinned the address gets either way.
+pub(crate) enum Target {
+    /// Resolved by the proxy.
+    Domain { host: String, port: u16 },
+    /// Resolved by this client.
+    Addr(SocketAddr),
+}
+
+/// Opens a tunnel to `target` over an already-connected stream to the proxy.
+///
+/// On return the stream carries nothing but the tunnel, so TLS and the WebSocket
+/// handshake run over it exactly as they would over a direct socket.
+pub(crate) async fn connect<S>(stream: &mut S, proxy: &Proxy, target: &Target) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    // A domain goes into a single length byte, so an oversized one cannot be asked for at
+    // all. Checking before the greeting keeps a doomed request off the wire.
+    if let Target::Domain { host, .. } = target {
+        if host.len() > MAX_HOSTNAME_LEN {
+            return Err(Socks5Error::HostnameTooLong.into());
+        }
+    }
+
+    negotiate(stream, proxy).await?;
+    send_request(stream, target).await?;
+    read_reply(stream).await
+}
+
+/// Offers the methods this client supports and runs whichever one the proxy picks.
+async fn negotiate<S>(stream: &mut S, proxy: &Proxy) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let greeting: &[u8] = match proxy.auth {
+        Some(_) => &[VERSION, 2, METHOD_NONE, METHOD_USERPASS],
+        None => &[VERSION, 1, METHOD_NONE],
+    };
+    stream.write_all(greeting).await?;
+    stream.flush().await?;
+
+    let mut chosen = [0; 2];
+    stream.read_exact(&mut chosen).await?;
+
+    if chosen[0] != VERSION {
+        return Err(Socks5Error::UnsupportedVersion(chosen[0]).into());
+    }
+
+    match (chosen[1], proxy.auth.as_ref()) {
+        (METHOD_NONE, _) => Ok(()),
+        (METHOD_USERPASS, Some(auth)) => authenticate(stream, auth).await,
+        (METHOD_UNACCEPTABLE, _) => Err(Socks5Error::NoAcceptableAuth.into()),
+        (method, _) => Err(Socks5Error::UnsupportedMethod(method).into()),
+    }
+}
+
+/// Runs the RFC 1929 username/password sub-negotiation.
+async fn authenticate<S>(stream: &mut S, auth: &Auth) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let username = auth.username.as_bytes();
+    let password = auth.password.0.as_bytes();
+
+    let mut request = Vec::with_capacity(3 + username.len() + password.len());
+    request.push(AUTH_VERSION);
+    request.push(username.len() as u8);
+    request.extend_from_slice(username);
+    request.push(password.len() as u8);
+    request.extend_from_slice(password);
+
+    stream.write_all(&request).await?;
+    stream.flush().await?;
+
+    let mut status = [0; 2];
+    stream.read_exact(&mut status).await?;
+
+    if status[0] != AUTH_VERSION {
+        return Err(Socks5Error::UnsupportedVersion(status[0]).into());
+    }
+    if status[1] != 0 {
+        return Err(Socks5Error::AuthFailed(status[1]).into());
+    }
+
+    Ok(())
+}
+
+/// Sends the `CONNECT` request for the target.
+async fn send_request<S>(stream: &mut S, target: &Target) -> Result<()>
+where
+    S: AsyncWrite + Unpin,
+{
+    let mut request = vec![VERSION, CMD_CONNECT, 0];
+
+    match target {
+        Target::Domain { host, port } => {
+            request.push(ATYP_DOMAIN);
+            request.push(host.len() as u8);
+            request.extend_from_slice(host.as_bytes());
+            request.extend_from_slice(&port.to_be_bytes());
+        }
+        Target::Addr(SocketAddr::V4(addr)) => {
+            request.push(ATYP_IPV4);
+            request.extend_from_slice(&addr.ip().octets());
+            request.extend_from_slice(&addr.port().to_be_bytes());
+        }
+        Target::Addr(SocketAddr::V6(addr)) => {
+            request.push(ATYP_IPV6);
+            request.extend_from_slice(&addr.ip().octets());
+            request.extend_from_slice(&addr.port().to_be_bytes());
+        }
+    }
+
+    stream.write_all(&request).await?;
+    stream.flush().await?;
+
+    Ok(())
+}
+
+/// Reads the reply, including the bound address, so the stream is left at the first byte
+/// the target itself sent.
+async fn read_reply<S>(stream: &mut S) -> Result<()>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut head = [0; 4];
+    stream.read_exact(&mut head).await?;
+
+    if head[0] != VERSION {
+        return Err(Socks5Error::UnsupportedVersion(head[0]).into());
+    }
+    if head[1] != 0 {
+        return Err(Socks5Error::Rejected(ReplyCode::from(head[1])).into());
+    }
+
+    let address_len = match head[3] {
+        ATYP_IPV4 => 4,
+        ATYP_IPV6 => 16,
+        ATYP_DOMAIN => {
+            let mut len = [0; 1];
+            stream.read_exact(&mut len).await?;
+            usize::from(len[0])
+        }
+        atyp => return Err(Socks5Error::InvalidAddressType(atyp).into()),
+    };
+
+    // The bound address and port are of no use to a client that only wanted a tunnel, but
+    // they have to leave the stream so the bytes after them are the target's.
+    let mut bound = vec![0; address_len + 2];
+    stream.read_exact(&mut bound).await?;
+
+    Ok(())
+}
+
+/// The reply code a proxy returns when it refuses a `CONNECT` (RFC 1928 section 6).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReplyCode {
+    /// General SOCKS server failure.
+    GeneralFailure,
+    /// Connection not allowed by ruleset.
+    NotAllowed,
+    /// Network unreachable.
+    NetworkUnreachable,
+    /// Host unreachable.
+    HostUnreachable,
+    /// Connection refused by the target.
+    ConnectionRefused,
+    /// TTL expired.
+    TtlExpired,
+    /// Command not supported.
+    CommandNotSupported,
+    /// Address type not supported.
+    AddressTypeNotSupported,
+    /// A code this version of the protocol does not define.
+    Unassigned(u8),
+}
+
+impl From<u8> for ReplyCode {
+    fn from(code: u8) -> Self {
+        match code {
+            1 => Self::GeneralFailure,
+            2 => Self::NotAllowed,
+            3 => Self::NetworkUnreachable,
+            4 => Self::HostUnreachable,
+            5 => Self::ConnectionRefused,
+            6 => Self::TtlExpired,
+            7 => Self::CommandNotSupported,
+            8 => Self::AddressTypeNotSupported,
+            code => Self::Unassigned(code),
+        }
+    }
+}
+
+impl fmt::Display for ReplyCode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::GeneralFailure => f.write_str("general failure"),
+            Self::NotAllowed => f.write_str("connection not allowed by ruleset"),
+            Self::NetworkUnreachable => f.write_str("network unreachable"),
+            Self::HostUnreachable => f.write_str("host unreachable"),
+            Self::ConnectionRefused => f.write_str("connection refused"),
+            Self::TtlExpired => f.write_str("ttl expired"),
+            Self::CommandNotSupported => f.write_str("command not supported"),
+            Self::AddressTypeNotSupported => f.write_str("address type not supported"),
+            Self::Unassigned(code) => write!(f, "unassigned reply code {code}"),
+        }
+    }
 }
 
 /// Everything that can go wrong talking to a SOCKS5 proxy.
@@ -140,11 +377,41 @@ pub enum Socks5Error {
     /// RFC 1929 cannot carry a username or password longer than 255 bytes.
     #[error("proxy credentials are longer than 255 bytes")]
     CredentialsTooLong,
+
+    /// A `CONNECT` request cannot carry a hostname longer than 255 bytes.
+    #[error("target hostname is longer than 255 bytes")]
+    HostnameTooLong,
+
+    /// The proxy answered with a version this client does not speak.
+    #[error("proxy replied with unsupported version {0}")]
+    UnsupportedVersion(u8),
+
+    /// The proxy rejected every authentication method offered.
+    #[error("proxy accepts none of the offered authentication methods")]
+    NoAcceptableAuth,
+
+    /// The proxy picked a method that was never offered.
+    #[error("proxy selected unsupported authentication method {0}")]
+    UnsupportedMethod(u8),
+
+    /// The proxy rejected the credentials.
+    #[error("proxy rejected the credentials with status {0}")]
+    AuthFailed(u8),
+
+    /// The proxy refused to open the tunnel.
+    #[error("proxy refused the connection: {0}")]
+    Rejected(ReplyCode),
+
+    /// The reply carried a bound address of an unknown type.
+    #[error("proxy replied with unsupported address type {0}")]
+    InvalidAddressType(u8),
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::WebSocketError;
+    use std::net::Ipv6Addr;
     use url::{Host, Url};
 
     fn proxy(url: &str) -> Proxy {
@@ -203,7 +470,10 @@ mod tests {
     #[test]
     fn rejects_a_non_socks5_scheme() {
         let err = Proxy::socks5("http://127.0.0.1:8080".parse().expect("url")).unwrap_err();
-        assert!(matches!(err, Socks5Error::UnsupportedScheme(_)));
+        assert!(matches!(
+            err,
+            WebSocketError::Socks5(Socks5Error::UnsupportedScheme(_))
+        ));
     }
 
     #[test]
@@ -214,7 +484,7 @@ mod tests {
             .expect("url");
         assert!(matches!(
             Proxy::socks5(url).unwrap_err(),
-            Socks5Error::CredentialsTooLong
+            WebSocketError::Socks5(Socks5Error::CredentialsTooLong)
         ));
     }
 
@@ -222,5 +492,310 @@ mod tests {
     fn debug_never_prints_the_password() {
         let printed = format!("{:?}", proxy("socks5h://user:hunter2@127.0.0.1:1080"));
         assert!(!printed.contains("hunter2"), "{printed}");
+    }
+
+    use tokio::io::{duplex, AsyncReadExt, AsyncWriteExt, DuplexStream};
+
+    /// Reads exactly `n` bytes from the fake proxy's end of the pipe.
+    async fn read_n(io: &mut DuplexStream, n: usize) -> Vec<u8> {
+        let mut buf = vec![0; n];
+        io.read_exact(&mut buf).await.expect("read");
+        buf
+    }
+
+    /// A successful `CONNECT` reply bound to 0.0.0.0:0.
+    const OK_REPLY: &[u8] = &[5, 0, 0, 1, 0, 0, 0, 0, 0, 0];
+
+    fn target(host: &str, port: u16) -> Target {
+        Target::Domain {
+            host: host.to_string(),
+            port,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_plain_connect_asks_the_proxy_for_the_target_by_name() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        let fake = tokio::spawn(async move {
+            assert_eq!(read_n(&mut server, 3).await, [5, 1, 0]);
+            server.write_all(&[5, 0]).await.expect("write");
+
+            let request = read_n(&mut server, 4 + 1 + 11 + 2).await;
+            assert_eq!(request, b"\x05\x01\x00\x03\x0bexample.com\x01\xbb");
+
+            server.write_all(OK_REPLY).await.expect("write");
+        });
+
+        connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .expect("handshake");
+        fake.await.expect("fake proxy");
+    }
+
+    #[tokio::test]
+    async fn credentials_are_offered_and_sent() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://user:pass@127.0.0.1:1080");
+
+        let fake = tokio::spawn(async move {
+            assert_eq!(read_n(&mut server, 4).await, [5, 2, 0, 2]);
+            server.write_all(&[5, 2]).await.expect("write");
+
+            assert_eq!(read_n(&mut server, 11).await, b"\x01\x04user\x04pass");
+            server.write_all(&[1, 0]).await.expect("write");
+
+            let _ = read_n(&mut server, 4 + 1 + 11 + 2).await;
+            server.write_all(OK_REPLY).await.expect("write");
+        });
+
+        connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .expect("handshake");
+        fake.await.expect("fake proxy");
+    }
+
+    #[tokio::test]
+    async fn a_rejected_password_fails_the_connection() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://user:pass@127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 4).await;
+            server.write_all(&[5, 2]).await.expect("write");
+            let _ = read_n(&mut server, 11).await;
+            server.write_all(&[1, 1]).await.expect("write");
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, WebSocketError::Socks5(Socks5Error::AuthFailed(1))),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_proxy_that_accepts_no_method_fails_the_connection() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0xFF]).await.expect("write");
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, WebSocketError::Socks5(Socks5Error::NoAcceptableAuth)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_method_that_was_never_offered_fails_the_connection() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            // Username/password, which a proxy without credentials never offered.
+            server.write_all(&[5, 2]).await.expect("write");
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                WebSocketError::Socks5(Socks5Error::UnsupportedMethod(2))
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_greeting_from_another_version_fails_the_connection() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[4, 0]).await.expect("write");
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                WebSocketError::Socks5(Socks5Error::UnsupportedVersion(4))
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_reply_code_becomes_a_typed_error() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0]).await.expect("write");
+            let _ = read_n(&mut server, 4 + 1 + 11 + 2).await;
+            server
+                .write_all(&[5, 5, 0, 1, 0, 0, 0, 0, 0, 0])
+                .await
+                .expect("write");
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                WebSocketError::Socks5(Socks5Error::Rejected(ReplyCode::ConnectionRefused))
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_ip_target_is_sent_as_an_address_not_a_name() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5://127.0.0.1:1080");
+
+        let fake = tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0]).await.expect("write");
+
+            assert_eq!(
+                read_n(&mut server, 10).await,
+                [5, 1, 0, 1, 93, 184, 216, 34, 0x01, 0xbb]
+            );
+            server.write_all(OK_REPLY).await.expect("write");
+        });
+
+        let target = Target::Addr("93.184.216.34:443".parse().expect("addr"));
+        connect(&mut client, &proxy, &target)
+            .await
+            .expect("handshake");
+        fake.await.expect("fake proxy");
+    }
+
+    #[tokio::test]
+    async fn an_ipv6_target_is_sent_as_a_16_byte_address() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5://127.0.0.1:1080");
+
+        let fake = tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0]).await.expect("write");
+
+            let request = read_n(&mut server, 22).await;
+            assert_eq!(&request[..4], [5, 1, 0, 4]);
+            assert_eq!(&request[4..20], Ipv6Addr::LOCALHOST.octets());
+            assert_eq!(&request[20..], [0x01, 0xbb]);
+
+            server.write_all(OK_REPLY).await.expect("write");
+        });
+
+        let target = Target::Addr("[::1]:443".parse().expect("addr"));
+        connect(&mut client, &proxy, &target)
+            .await
+            .expect("handshake");
+        fake.await.expect("fake proxy");
+    }
+
+    #[tokio::test]
+    async fn the_bound_address_is_consumed_so_the_tunnel_starts_clean() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0]).await.expect("write");
+            let _ = read_n(&mut server, 4 + 1 + 11 + 2).await;
+
+            // A reply bound to an IPv6 address, immediately followed by tunnelled data.
+            let mut reply = vec![5, 0, 0, 4];
+            reply.extend_from_slice(&Ipv6Addr::LOCALHOST.octets());
+            reply.extend_from_slice(&[0x01, 0xbb]);
+            reply.extend_from_slice(b"first byte of the tunnel");
+            server.write_all(&reply).await.expect("write");
+        });
+
+        connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .expect("handshake");
+
+        let mut tunnelled = [0; 24];
+        client.read_exact(&mut tunnelled).await.expect("read");
+        assert_eq!(&tunnelled, b"first byte of the tunnel");
+    }
+
+    #[tokio::test]
+    async fn a_bound_address_of_an_unknown_type_fails_the_connection() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0]).await.expect("write");
+            let _ = read_n(&mut server, 4 + 1 + 11 + 2).await;
+            server.write_all(&[5, 0, 0, 9, 0, 0]).await.expect("write");
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                WebSocketError::Socks5(Socks5Error::InvalidAddressType(9))
+            ),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_hostname_that_does_not_fit_the_request_is_rejected() {
+        let (mut client, _server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        let err = connect(&mut client, &proxy, &target(&"h".repeat(256), 443))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, WebSocketError::Socks5(Socks5Error::HostnameTooLong)),
+            "{err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_truncated_reply_is_an_io_error() {
+        let (mut client, mut server) = duplex(1024);
+        let proxy = proxy("socks5h://127.0.0.1:1080");
+
+        tokio::spawn(async move {
+            let _ = read_n(&mut server, 3).await;
+            server.write_all(&[5, 0]).await.expect("write");
+            let _ = read_n(&mut server, 4 + 1 + 11 + 2).await;
+            server.write_all(&[5, 0, 0]).await.expect("write");
+            drop(server);
+        });
+
+        let err = connect(&mut client, &proxy, &target("example.com", 443))
+            .await
+            .unwrap_err();
+        assert!(err.is_io_error(), "{err:?}");
     }
 }

--- a/src/native/socks5.rs
+++ b/src/native/socks5.rs
@@ -1,0 +1,226 @@
+//! SOCKS5 (RFC 1928) client support for outgoing connections.
+//!
+//! A [`Proxy`] handed to the connection builder makes the client dial the proxy and ask
+//! it to open a tunnel to the WebSocket host.
+//! Everything above that, TLS included, then runs end to end through the tunnel, so the
+//! proxy sees only ciphertext for a `wss://` URL.
+
+use std::{fmt, net::IpAddr};
+
+use percent_encoding::percent_decode_str;
+use thiserror::Error;
+use url::{Host, Url};
+
+/// The port a SOCKS5 proxy is assumed to listen on when the URL does not say.
+const DEFAULT_PORT: u16 = 1080;
+
+/// RFC 1929 gives the username and password a single length byte each.
+const MAX_CREDENTIAL_LEN: usize = 255;
+
+/// A SOCKS5 proxy to dial through.
+///
+/// Build one from a URL with [`Proxy::socks5`]. Both scheme spellings are accepted and
+/// they differ in who resolves the WebSocket host: `socks5h://` sends the hostname to the
+/// proxy, `socks5://` resolves it locally and sends an address.
+///
+/// ```
+/// use yawc::Proxy;
+///
+/// # fn main() -> yawc::Result<()> {
+/// let proxy = Proxy::socks5("socks5h://user:pass@127.0.0.1:1080".parse()?)?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct Proxy {
+    /// Where the proxy listens.
+    pub(crate) host: Host<String>,
+    /// The proxy's port, defaulting to 1080.
+    pub(crate) port: u16,
+    /// Credentials for RFC 1929 username/password authentication, if the proxy wants any.
+    pub(crate) auth: Option<Auth>,
+    /// Whether the proxy resolves the target hostname, rather than this client.
+    pub(crate) remote_dns: bool,
+}
+
+/// RFC 1929 username/password credentials.
+#[derive(Debug, Clone)]
+pub(crate) struct Auth {
+    pub(crate) username: String,
+    pub(crate) password: Password,
+}
+
+/// A password that stays out of logs.
+///
+/// `Proxy` derives `Debug` so it can be printed while debugging a connection, and this
+/// keeps that from spilling the credential.
+#[derive(Clone)]
+pub(crate) struct Password(pub(crate) String);
+
+impl fmt::Debug for Password {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Password(***)")
+    }
+}
+
+impl Proxy {
+    /// Parses a `socks5://` or `socks5h://` URL into a proxy definition.
+    ///
+    /// Credentials come from the URL's userinfo and are percent-decoded, so a password
+    /// containing `@` or `:` can be written as `%40` and `%3A`. A URL without a port uses
+    /// 1080.
+    pub fn socks5(url: Url) -> Result<Self, Socks5Error> {
+        let remote_dns = match url.scheme() {
+            "socks5" => false,
+            "socks5h" => true,
+            scheme => return Err(Socks5Error::UnsupportedScheme(scheme.to_string())),
+        };
+
+        let host = match url.host() {
+            // A non-special scheme leaves an IPv4 literal as a domain, and which address
+            // type the request carries depends on telling them apart.
+            Some(Host::Domain(domain)) => match domain.parse::<IpAddr>() {
+                Ok(IpAddr::V4(ip)) => Host::Ipv4(ip),
+                Ok(IpAddr::V6(ip)) => Host::Ipv6(ip),
+                Err(_) => Host::Domain(domain.to_string()),
+            },
+            Some(Host::Ipv4(ip)) => Host::Ipv4(ip),
+            Some(Host::Ipv6(ip)) => Host::Ipv6(ip),
+            None => return Err(Socks5Error::MissingHost),
+        };
+
+        let auth = match decode(url.username())? {
+            username if username.is_empty() => None,
+            username => Some(Auth {
+                username,
+                password: Password(decode(url.password().unwrap_or_default())?),
+            }),
+        };
+
+        if let Some(auth) = auth.as_ref() {
+            if auth.username.len() > MAX_CREDENTIAL_LEN
+                || auth.password.0.len() > MAX_CREDENTIAL_LEN
+            {
+                return Err(Socks5Error::CredentialsTooLong);
+            }
+        }
+
+        Ok(Self {
+            host,
+            port: url.port().unwrap_or(DEFAULT_PORT),
+            auth,
+            remote_dns,
+        })
+    }
+}
+
+/// Percent-decodes one half of a URL's userinfo.
+fn decode(value: &str) -> Result<String, Socks5Error> {
+    percent_decode_str(value)
+        .decode_utf8()
+        .map(|decoded| decoded.into_owned())
+        .map_err(|_| Socks5Error::InvalidCredentials)
+}
+
+/// Everything that can go wrong talking to a SOCKS5 proxy.
+#[derive(Debug, Error)]
+pub enum Socks5Error {
+    /// The proxy URL used a scheme other than `socks5` or `socks5h`.
+    #[error("unsupported proxy scheme: {0}")]
+    UnsupportedScheme(String),
+
+    /// The proxy URL has no host to connect to.
+    #[error("proxy url has no host")]
+    MissingHost,
+
+    /// The userinfo in the proxy URL is not valid UTF-8 once percent-decoded.
+    #[error("proxy credentials are not valid UTF-8")]
+    InvalidCredentials,
+
+    /// RFC 1929 cannot carry a username or password longer than 255 bytes.
+    #[error("proxy credentials are longer than 255 bytes")]
+    CredentialsTooLong,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::{Host, Url};
+
+    fn proxy(url: &str) -> Proxy {
+        Proxy::socks5(url.parse().expect("url")).expect("proxy")
+    }
+
+    #[test]
+    fn socks5h_scheme_asks_the_proxy_to_resolve() {
+        assert!(proxy("socks5h://127.0.0.1:1080").remote_dns);
+    }
+
+    #[test]
+    fn socks5_scheme_resolves_locally() {
+        assert!(!proxy("socks5://127.0.0.1:1080").remote_dns);
+    }
+
+    #[test]
+    fn missing_port_defaults_to_1080() {
+        assert_eq!(proxy("socks5h://proxy.example").port, 1080);
+    }
+
+    #[test]
+    fn host_keeps_its_parsed_form() {
+        assert_eq!(
+            proxy("socks5h://[::1]:9050").host,
+            Host::<String>::Ipv6("::1".parse().expect("addr"))
+        );
+        assert_eq!(
+            proxy("socks5h://proxy.example:1080").host,
+            Host::Domain("proxy.example".to_string())
+        );
+    }
+
+    #[test]
+    fn an_ip_literal_is_recognised_as_an_ip_host() {
+        assert_eq!(
+            proxy("socks5h://127.0.0.1:1080").host,
+            Host::<String>::Ipv4("127.0.0.1".parse().expect("addr"))
+        );
+    }
+
+    #[test]
+    fn userinfo_becomes_credentials() {
+        let auth = proxy("socks5h://user:p%40ss@127.0.0.1:1080")
+            .auth
+            .expect("auth");
+        assert_eq!(auth.username, "user");
+        assert_eq!(auth.password.0, "p@ss");
+    }
+
+    #[test]
+    fn no_userinfo_means_no_credentials() {
+        assert!(proxy("socks5h://127.0.0.1:1080").auth.is_none());
+    }
+
+    #[test]
+    fn rejects_a_non_socks5_scheme() {
+        let err = Proxy::socks5("http://127.0.0.1:8080".parse().expect("url")).unwrap_err();
+        assert!(matches!(err, Socks5Error::UnsupportedScheme(_)));
+    }
+
+    #[test]
+    fn rejects_credentials_that_do_not_fit_rfc_1929() {
+        let long = "u".repeat(256);
+        let url: Url = format!("socks5h://{long}:pass@127.0.0.1:1080")
+            .parse()
+            .expect("url");
+        assert!(matches!(
+            Proxy::socks5(url).unwrap_err(),
+            Socks5Error::CredentialsTooLong
+        ));
+    }
+
+    #[test]
+    fn debug_never_prints_the_password() {
+        let printed = format!("{:?}", proxy("socks5h://user:hunter2@127.0.0.1:1080"));
+        assert!(!printed.contains("hunter2"), "{printed}");
+    }
+}

--- a/src/native/socks5.rs
+++ b/src/native/socks5.rs
@@ -140,6 +140,11 @@ impl Proxy {
     /// Credentials come from the URL's userinfo and are percent-decoded, so a password
     /// containing `@` or `:` can be written as `%40` and `%3A`. A URL without a port uses
     /// 1080.
+    ///
+    /// Prefer `socks5h://` unless the proxy cannot resolve the target itself. A `CONNECT`
+    /// request carries a single address, so `socks5://` sends only the first one the
+    /// resolver returns, and on a dual-stack host that can be an address the proxy has no
+    /// route to.
     pub fn socks5(url: Url) -> Result<Self> {
         let remote_dns = match url.scheme() {
             "socks5" => false,

--- a/src/native/socks5.rs
+++ b/src/native/socks5.rs
@@ -6,13 +6,16 @@
 //! proxy sees only ciphertext for a `wss://` URL.
 
 use std::{
-    fmt,
+    fmt, io,
     net::{IpAddr, SocketAddr},
 };
 
 use percent_encoding::percent_decode_str;
 use thiserror::Error;
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use tokio::{
+    io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
+    net::{lookup_host, TcpStream},
+};
 use url::{Host, Url};
 
 use crate::Result;
@@ -355,6 +358,48 @@ impl fmt::Display for ReplyCode {
             Self::CommandNotSupported => f.write_str("command not supported"),
             Self::AddressTypeNotSupported => f.write_str("address type not supported"),
             Self::Unassigned(code) => write!(f, "unassigned reply code {code}"),
+        }
+    }
+}
+
+impl Proxy {
+    /// Connects to the proxy itself.
+    pub(crate) async fn dial(&self) -> Result<TcpStream> {
+        let stream = match &self.host {
+            Host::Domain(domain) => TcpStream::connect((domain.as_str(), self.port)).await?,
+            Host::Ipv4(ip) => TcpStream::connect(SocketAddr::from((*ip, self.port))).await?,
+            Host::Ipv6(ip) => TcpStream::connect(SocketAddr::from((*ip, self.port))).await?,
+        };
+
+        Ok(stream)
+    }
+
+    /// Works out what the proxy should be asked to connect to.
+    ///
+    /// An address the caller pinned is used as it stands. Otherwise a hostname is either
+    /// passed on for the proxy to resolve, which is what `socks5h://` means, or resolved
+    /// here first.
+    pub(crate) async fn target(&self, url: &Url, pinned: Option<SocketAddr>) -> Result<Target> {
+        if let Some(addr) = pinned {
+            return Ok(Target::Addr(addr));
+        }
+
+        let port = url.port_or_known_default().expect("port");
+
+        match url.host().expect("hostname") {
+            Host::Ipv4(ip) => Ok(Target::Addr(SocketAddr::from((ip, port)))),
+            Host::Ipv6(ip) => Ok(Target::Addr(SocketAddr::from((ip, port)))),
+            Host::Domain(domain) if self.remote_dns => Ok(Target::Domain {
+                host: domain.to_string(),
+                port,
+            }),
+            Host::Domain(domain) => lookup_host((domain, port))
+                .await?
+                .next()
+                .map(Target::Addr)
+                .ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "no address for host").into()
+                }),
         }
     }
 }

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -337,3 +337,41 @@ async fn a_refused_tunnel_surfaces_as_a_typed_error() {
         "{err:?}"
     );
 }
+
+/// The HTTP/2 handshake dials through the same path, so the proxy applies there too.
+#[cfg(feature = "http2")]
+#[tokio::test]
+async fn the_http2_handshake_also_goes_through_the_proxy() {
+    use hyper::server::conn::http2;
+    use hyper_util::rt::TokioExecutor;
+    use yawc::HttpVersion;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let echo = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let _ = http2::Builder::new(TokioExecutor::new())
+                    .enable_connect_protocol()
+                    .serve_connection(TokioIo::new(stream), service_fn(handle))
+                    .await;
+            });
+        }
+    });
+
+    let (proxy, mut requested) = MockProxy::default().spawn().await;
+
+    let mut ws = WebSocket::connect(format!("ws://{echo}/chat").parse().unwrap())
+        .http_version(HttpVersion::Http2)
+        .with_proxy(Proxy::socks5(format!("socks5h://{proxy}").parse().unwrap()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(requested.recv().await.unwrap(), Requested::Addr(echo));
+
+    ws.send(Frame::text("over h2 and socks5")).await.unwrap();
+    assert_eq!(
+        ws.next().await.unwrap().payload().as_ref(),
+        b"over h2 and socks5"
+    );
+}

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -7,7 +7,10 @@
 // The wasm build compiles integration tests too, and none of this exists there.
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::{convert::Infallible, net::SocketAddr};
+use std::{
+    convert::Infallible,
+    net::{IpAddr, SocketAddr},
+};
 
 use bytes::Bytes;
 use futures::{SinkExt, StreamExt};
@@ -16,7 +19,7 @@ use hyper::{body::Incoming, server::conn::http1, service::service_fn, Request, R
 use hyper_util::rt::TokioIo;
 use tokio::{
     io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt},
-    net::{TcpListener, TcpStream},
+    net::{lookup_host, TcpListener, TcpStream},
     sync::mpsc,
 };
 use yawc::{
@@ -116,6 +119,13 @@ impl MockProxy {
                     port: u16::from_be_bytes(port),
                 }
             }
+            4 => {
+                let mut ip = [0; 16];
+                client.read_exact(&mut ip).await.unwrap();
+                let mut port = [0; 2];
+                client.read_exact(&mut port).await.unwrap();
+                Requested::Addr(SocketAddr::from((ip, u16::from_be_bytes(port))))
+            }
             atyp => panic!("unexpected address type {atyp}"),
         };
 
@@ -149,9 +159,27 @@ async fn read_prefixed(stream: &mut TcpStream) -> String {
     String::from_utf8(value).unwrap()
 }
 
-/// Starts an HTTP/1.1 WebSocket echo server and returns the address it listens on.
+/// Starts an HTTP/1.1 WebSocket echo server on loopback.
 async fn spawn_echo_server() -> SocketAddr {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    spawn_echo_server_at("127.0.0.1".parse().unwrap()).await
+}
+
+/// The address `localhost` resolves to first.
+///
+/// A client resolving the target itself can only send the proxy one address, so this is
+/// the one it picks, and on a dual-stack host it is not always IPv4.
+async fn first_localhost_address() -> IpAddr {
+    lookup_host(("localhost", 0))
+        .await
+        .unwrap()
+        .next()
+        .unwrap()
+        .ip()
+}
+
+/// Starts an HTTP/1.1 WebSocket echo server on `ip` and returns the address it listens on.
+async fn spawn_echo_server_at(ip: IpAddr) -> SocketAddr {
+    let listener = TcpListener::bind(SocketAddr::new(ip, 0)).await.unwrap();
     let addr = listener.local_addr().unwrap();
 
     tokio::spawn(async move {
@@ -225,7 +253,9 @@ async fn socks5h_leaves_the_hostname_for_the_proxy_to_resolve() {
 
 #[tokio::test]
 async fn socks5_resolves_the_hostname_before_asking_the_proxy() {
-    let echo = spawn_echo_server().await;
+    // The echo server listens on whichever loopback address the client will resolve
+    // `localhost` to, since the request can only carry one of them.
+    let echo = spawn_echo_server_at(first_localhost_address().await).await;
     let (proxy, mut requested) = MockProxy::default().spawn().await;
 
     let url = format!("ws://localhost:{}/chat", echo.port());
@@ -234,13 +264,8 @@ async fn socks5_resolves_the_hostname_before_asking_the_proxy() {
         .await
         .unwrap();
 
-    // Which loopback address `localhost` resolves to is the host's business; that it was
-    // resolved here rather than passed on as a name is the point.
-    let Requested::Addr(addr) = requested.recv().await.unwrap() else {
-        panic!("the hostname was left for the proxy to resolve")
-    };
-    assert!(addr.ip().is_loopback(), "{addr}");
-    assert_eq!(addr.port(), echo.port());
+    // That the hostname was resolved here rather than passed on as a name is the point.
+    assert_eq!(requested.recv().await.unwrap(), Requested::Addr(echo));
 }
 
 #[tokio::test]

--- a/tests/socks5.rs
+++ b/tests/socks5.rs
@@ -1,0 +1,339 @@
+//! End-to-end tests for dialling through a SOCKS5 proxy.
+//!
+//! The proxy is a mock that speaks the server half of RFC 1928 and then relays bytes, so
+//! the tests cover what actually goes over the wire: which address type the request
+//! carries, whether credentials are sent, and what a refusal turns into.
+
+// The wasm build compiles integration tests too, and none of this exists there.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::{convert::Infallible, net::SocketAddr};
+
+use bytes::Bytes;
+use futures::{SinkExt, StreamExt};
+use http_body_util::Empty;
+use hyper::{body::Incoming, server::conn::http1, service::service_fn, Request, Response};
+use hyper_util::rt::TokioIo;
+use tokio::{
+    io::{copy_bidirectional, AsyncReadExt, AsyncWriteExt},
+    net::{TcpListener, TcpStream},
+    sync::mpsc,
+};
+use yawc::{
+    frame::OpCode, Frame, Options, Proxy, ReplyCode, Socks5Error, WebSocket, WebSocketError,
+};
+
+/// What the mock proxy was asked to connect to.
+#[derive(Debug, PartialEq, Eq)]
+enum Requested {
+    Domain { host: String, port: u16 },
+    Addr(SocketAddr),
+}
+
+/// Credentials the mock proxy demands.
+struct Credentials {
+    username: String,
+    password: String,
+}
+
+/// How the mock proxy behaves for one connection.
+#[derive(Default)]
+struct MockProxy {
+    /// When set, the proxy offers only username/password and checks what it is given.
+    credentials: Option<Credentials>,
+    /// The reply code to answer the `CONNECT` with. Anything but 0 skips the relay.
+    reply: u8,
+}
+
+impl MockProxy {
+    /// Starts the proxy and returns its address and a channel of what it was asked for.
+    async fn spawn(self) -> (SocketAddr, mpsc::UnboundedReceiver<Requested>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            while let Ok((mut client, _)) = listener.accept().await {
+                self.negotiate(&mut client, &tx).await;
+            }
+        });
+
+        (addr, rx)
+    }
+
+    /// Runs the server half of the handshake, reports what was asked for, then relays
+    /// until either side closes.
+    async fn negotiate(&self, client: &mut TcpStream, requests: &mpsc::UnboundedSender<Requested>) {
+        let mut greeting = [0; 2];
+        client.read_exact(&mut greeting).await.unwrap();
+        assert_eq!(greeting[0], 5);
+
+        let mut methods = vec![0; usize::from(greeting[1])];
+        client.read_exact(&mut methods).await.unwrap();
+
+        match &self.credentials {
+            Some(expected) => {
+                assert!(methods.contains(&2), "client never offered a password");
+                client.write_all(&[5, 2]).await.unwrap();
+
+                let mut version = [0; 1];
+                client.read_exact(&mut version).await.unwrap();
+                assert_eq!(version[0], 1);
+
+                let username = read_prefixed(client).await;
+                let password = read_prefixed(client).await;
+
+                let ok = username == expected.username && password == expected.password;
+                client.write_all(&[1, u8::from(!ok)]).await.unwrap();
+                if !ok {
+                    return;
+                }
+            }
+            None => {
+                assert!(methods.contains(&0));
+                client.write_all(&[5, 0]).await.unwrap();
+            }
+        }
+
+        let mut head = [0; 4];
+        client.read_exact(&mut head).await.unwrap();
+        assert_eq!(&head[..3], [5, 1, 0]);
+
+        let requested = match head[3] {
+            1 => {
+                let mut rest = [0; 6];
+                client.read_exact(&mut rest).await.unwrap();
+                let ip = [rest[0], rest[1], rest[2], rest[3]];
+                let port = u16::from_be_bytes([rest[4], rest[5]]);
+                Requested::Addr(SocketAddr::from((ip, port)))
+            }
+            3 => {
+                let host = read_prefixed(client).await;
+                let mut port = [0; 2];
+                client.read_exact(&mut port).await.unwrap();
+                Requested::Domain {
+                    host,
+                    port: u16::from_be_bytes(port),
+                }
+            }
+            atyp => panic!("unexpected address type {atyp}"),
+        };
+
+        client
+            .write_all(&[5, self.reply, 0, 1, 0, 0, 0, 0, 0, 0])
+            .await
+            .unwrap();
+
+        let target = match &requested {
+            Requested::Domain { host, port } => format!("{host}:{port}"),
+            Requested::Addr(addr) => addr.to_string(),
+        };
+
+        // Reported before relaying, which runs for as long as the connection lives.
+        let refused = self.reply != 0;
+        let _ = requests.send(requested);
+
+        if !refused {
+            let mut upstream = TcpStream::connect(target).await.unwrap();
+            let _ = copy_bidirectional(client, &mut upstream).await;
+        }
+    }
+}
+
+/// Reads a length-prefixed string, the shape RFC 1928 and RFC 1929 use throughout.
+async fn read_prefixed(stream: &mut TcpStream) -> String {
+    let mut len = [0; 1];
+    stream.read_exact(&mut len).await.unwrap();
+    let mut value = vec![0; usize::from(len[0])];
+    stream.read_exact(&mut value).await.unwrap();
+    String::from_utf8(value).unwrap()
+}
+
+/// Starts an HTTP/1.1 WebSocket echo server and returns the address it listens on.
+async fn spawn_echo_server() -> SocketAddr {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                let service = service_fn(handle);
+                let _ = http1::Builder::new()
+                    .serve_connection(TokioIo::new(stream), service)
+                    .with_upgrades()
+                    .await;
+            });
+        }
+    });
+
+    addr
+}
+
+/// Upgrades the request and echoes every data frame back.
+async fn handle(mut req: Request<Incoming>) -> Result<Response<Empty<Bytes>>, Infallible> {
+    let (response, fut) = WebSocket::upgrade_with_options(&mut req, Options::default()).unwrap();
+
+    tokio::spawn(async move {
+        let mut ws = fut.await.unwrap();
+        while let Some(frame) = ws.next().await {
+            if matches!(frame.opcode(), OpCode::Text | OpCode::Binary)
+                && ws.send(frame).await.is_err()
+            {
+                break;
+            }
+        }
+    });
+
+    Ok(response)
+}
+
+#[tokio::test]
+async fn echoes_through_the_proxy() {
+    let echo = spawn_echo_server().await;
+    let (proxy, _requested) = MockProxy::default().spawn().await;
+
+    let mut ws = WebSocket::connect(format!("ws://{echo}/chat").parse().unwrap())
+        .with_proxy(Proxy::socks5(format!("socks5h://{proxy}").parse().unwrap()).unwrap())
+        .await
+        .unwrap();
+
+    ws.send(Frame::text("through the tunnel")).await.unwrap();
+    let frame = ws.next().await.unwrap();
+    assert_eq!(frame.opcode(), OpCode::Text);
+    assert_eq!(frame.payload().as_ref(), b"through the tunnel");
+}
+
+#[tokio::test]
+async fn socks5h_leaves_the_hostname_for_the_proxy_to_resolve() {
+    let echo = spawn_echo_server().await;
+    let (proxy, mut requested) = MockProxy::default().spawn().await;
+
+    let url = format!("ws://localhost:{}/chat", echo.port());
+    let _ws = WebSocket::connect(url.parse().unwrap())
+        .with_proxy(Proxy::socks5(format!("socks5h://{proxy}").parse().unwrap()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        requested.recv().await.unwrap(),
+        Requested::Domain {
+            host: "localhost".to_string(),
+            port: echo.port(),
+        }
+    );
+}
+
+#[tokio::test]
+async fn socks5_resolves_the_hostname_before_asking_the_proxy() {
+    let echo = spawn_echo_server().await;
+    let (proxy, mut requested) = MockProxy::default().spawn().await;
+
+    let url = format!("ws://localhost:{}/chat", echo.port());
+    let _ws = WebSocket::connect(url.parse().unwrap())
+        .with_proxy(Proxy::socks5(format!("socks5://{proxy}").parse().unwrap()).unwrap())
+        .await
+        .unwrap();
+
+    // Which loopback address `localhost` resolves to is the host's business; that it was
+    // resolved here rather than passed on as a name is the point.
+    let Requested::Addr(addr) = requested.recv().await.unwrap() else {
+        panic!("the hostname was left for the proxy to resolve")
+    };
+    assert!(addr.ip().is_loopback(), "{addr}");
+    assert_eq!(addr.port(), echo.port());
+}
+
+#[tokio::test]
+async fn a_pinned_address_is_what_the_proxy_is_asked_for() {
+    let echo = spawn_echo_server().await;
+    let (proxy, mut requested) = MockProxy::default().spawn().await;
+
+    let _ws = WebSocket::connect("ws://example.invalid/chat".parse().unwrap())
+        .with_tcp_address(echo)
+        .with_proxy(Proxy::socks5(format!("socks5h://{proxy}").parse().unwrap()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(requested.recv().await.unwrap(), Requested::Addr(echo));
+}
+
+#[tokio::test]
+async fn credentials_from_the_url_are_accepted() {
+    let echo = spawn_echo_server().await;
+    let (proxy, _requested) = MockProxy {
+        credentials: Some(Credentials {
+            username: "user".to_string(),
+            password: "p@ss".to_string(),
+        }),
+        ..MockProxy::default()
+    }
+    .spawn()
+    .await;
+
+    let mut ws = WebSocket::connect(format!("ws://{echo}/chat").parse().unwrap())
+        .with_proxy(
+            Proxy::socks5(format!("socks5h://user:p%40ss@{proxy}").parse().unwrap()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    ws.send(Frame::text("authenticated")).await.unwrap();
+    assert_eq!(
+        ws.next().await.unwrap().payload().as_ref(),
+        b"authenticated"
+    );
+}
+
+#[tokio::test]
+async fn wrong_credentials_fail_the_connection() {
+    let echo = spawn_echo_server().await;
+    let (proxy, _requested) = MockProxy {
+        credentials: Some(Credentials {
+            username: "user".to_string(),
+            password: "right".to_string(),
+        }),
+        ..MockProxy::default()
+    }
+    .spawn()
+    .await;
+
+    let Err(err) = WebSocket::connect(format!("ws://{echo}/chat").parse().unwrap())
+        .with_proxy(
+            Proxy::socks5(format!("socks5h://user:wrong@{proxy}").parse().unwrap()).unwrap(),
+        )
+        .await
+    else {
+        panic!("the proxy accepted the wrong password")
+    };
+
+    assert!(
+        matches!(err, WebSocketError::Socks5(Socks5Error::AuthFailed(_))),
+        "{err:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_refused_tunnel_surfaces_as_a_typed_error() {
+    let echo = spawn_echo_server().await;
+    let (proxy, _requested) = MockProxy {
+        reply: 5,
+        ..MockProxy::default()
+    }
+    .spawn()
+    .await;
+
+    let Err(err) = WebSocket::connect(format!("ws://{echo}/chat").parse().unwrap())
+        .with_proxy(Proxy::socks5(format!("socks5h://{proxy}").parse().unwrap()).unwrap())
+        .await
+    else {
+        panic!("the refused tunnel became a connection")
+    };
+
+    assert!(
+        matches!(
+            err,
+            WebSocketError::Socks5(Socks5Error::Rejected(ReplyCode::ConnectionRefused))
+        ),
+        "{err:?}"
+    );
+}

--- a/yawcc/Cargo.lock
+++ b/yawcc/Cargo.lock
@@ -1624,6 +1624,7 @@ dependencies = [
  "js-sys",
  "log",
  "nom",
+ "percent-encoding",
  "pin-project",
  "rand",
  "send_wrapper",

--- a/yawcc/README.md
+++ b/yawcc/README.md
@@ -7,6 +7,7 @@ A command-line interface tool for WebSocket communication that supports both sec
 - Interactive WebSocket client with command history
 - Simple WebSocket server implementation
 - Support for both ws:// and wss:// connections
+- SOCKS5 proxy support, with optional username/password authentication
 - JSON validation and pretty-printing
 - Command history with search capabilities (Ctrl+R)
 - Inline comments support using // for quick search and documentation
@@ -39,6 +40,16 @@ yawcc c --input-as-json wss://fstream.binance.com/ws/btcusdt@aggTrade
 ```bash
 yawcc c https://echo.websocket.org --tcp-host 127.0.0.1:8080
 ```
+
+#### Through a SOCKS5 Proxy
+
+```bash
+yawcc c wss://echo.websocket.org --proxy socks5h://127.0.0.1:1080
+yawcc c wss://echo.websocket.org --proxy socks5h://user:pass@127.0.0.1:1080
+```
+
+`socks5h://` leaves the hostname for the proxy to resolve, `socks5://` resolves it
+locally. TLS runs end to end through the tunnel.
 
 ### Server Mode
 
@@ -74,6 +85,7 @@ Options:
   -H, --header <Headers>     Custom headers to send to the server in "Key: Value" format For example: --header "Authorization: Bearer token123"
       --input-as-json        When enabled, validates and pretty-prints received messages as JSON. Invalid JSON messages will result in an error
       --tcp-host <TCP_HOST>  Connect directly to a TCP host instead of using WebSocket URL. Format: host:port (e.g., "127.0.0.1:8080")
+      --proxy <PROXY>        Dial through a SOCKS5 proxy, for example "socks5h://127.0.0.1:1080" or "socks5h://user:pass@127.0.0.1:1080". socks5h:// lets the proxy resolve the host, socks5:// resolves it here
   -h, --help                 Print help (see more with '--help')
 ```
 

--- a/yawcc/src/client.rs
+++ b/yawcc/src/client.rs
@@ -12,7 +12,7 @@ use tokio::{
 use url::Url;
 use yawc::{
     frame::{Frame, OpCode},
-    CompressionLevel, HttpRequest, HttpRequestBuilder, Options, TcpWebSocket, WebSocket,
+    CompressionLevel, HttpRequest, HttpRequestBuilder, Options, Proxy, TcpWebSocket, WebSocket,
 };
 
 /// Command to connect and interact with a WebSocket server.
@@ -47,6 +47,12 @@ pub struct Cmd {
     #[arg(long)]
     tcp_host: Option<String>,
 
+    /// Dial through a SOCKS5 proxy, for example
+    /// "socks5h://127.0.0.1:1080" or "socks5h://user:pass@127.0.0.1:1080".
+    /// socks5h:// lets the proxy resolve the host, socks5:// resolves it here.
+    #[arg(long)]
+    proxy: Option<Url>,
+
     /// The WebSocket URL to connect to (ws:// or wss://)
     url: Url,
 }
@@ -68,6 +74,7 @@ async fn connect_with_tcp_host(
     url: &Url,
     tcp_host: &str,
     headers: &[String],
+    proxy: Option<&Proxy>,
     timeout_duration: Duration,
 ) -> anyhow::Result<TcpWebSocket> {
     // Resolve the TCP host to socket addresses
@@ -91,15 +98,15 @@ async fn connect_with_tcp_host(
         // Build a new request for each attempt since HttpRequestBuilder is not Clone
         let request = build_request(headers)?;
 
-        match timeout(
-            timeout_duration,
-            WebSocket::connect(url.clone())
-                .with_tcp_address(*addr)
-                .with_request(request)
-                .with_options(Options::default().with_compression_level(CompressionLevel::best())),
-        )
-        .await
-        {
+        let mut builder = WebSocket::connect(url.clone())
+            .with_tcp_address(*addr)
+            .with_request(request)
+            .with_options(Options::default().with_compression_level(CompressionLevel::best()));
+        if let Some(proxy) = proxy {
+            builder = builder.with_proxy(proxy.clone());
+        }
+
+        match timeout(timeout_duration, builder).await {
             Ok(Ok(ws)) => {
                 println!("Successfully connected via {}", addr);
                 return Ok(ws);
@@ -138,6 +145,7 @@ pub fn run(cmd: Cmd) -> anyhow::Result<()> {
     let printer = rl.create_external_printer().unwrap();
 
     let request_builder = build_request(&cmd.headers)?;
+    let proxy = cmd.proxy.clone().map(Proxy::socks5).transpose()?;
 
     let runtime = runtime::Builder::new_current_thread()
         .enable_all()
@@ -152,15 +160,18 @@ pub fn run(cmd: Cmd) -> anyhow::Result<()> {
             &cmd.url,
             tcp_host,
             &cmd.headers,
+            proxy.as_ref(),
             cmd.timeout,
         ))?
     } else {
-        runtime.block_on(timeout(
-            cmd.timeout,
-            WebSocket::connect(cmd.url.clone())
-                .with_request(request_builder)
-                .with_options(Options::default().with_compression_level(CompressionLevel::best())),
-        ))??
+        let mut builder = WebSocket::connect(cmd.url.clone())
+            .with_request(request_builder)
+            .with_options(Options::default().with_compression_level(CompressionLevel::best()));
+        if let Some(proxy) = proxy {
+            builder = builder.with_proxy(proxy);
+        }
+
+        runtime.block_on(timeout(cmd.timeout, builder))??
     };
 
     let url_string = cmd.url.to_string();


### PR DESCRIPTION
Adds SOCKS5 (RFC 1928) support to the client, so a connection can be dialled through a proxy instead of straight at the host.

```rust
let ws = WebSocket::connect("wss://example.com/socket".parse()?)
    .with_proxy(Proxy::socks5("socks5h://user:pass@127.0.0.1:1080".parse()?)?)
    .await?;
```

`socks5h://` sends the target hostname for the proxy to resolve, `socks5://` resolves it locally and sends an address, and `user:pass@` turns on RFC 1929 username/password authentication. A URL without a port uses 1080. TLS runs end to end through the tunnel, so a `wss://` connection is still negotiated with the target and the proxy only sees ciphertext.

### What is in here

- `src/native/socks5.rs`: the `Proxy` type and the handshake (greeting, optional username/password sub-negotiation, `CONNECT`, reply). The bound address in the reply is consumed, so the stream is left at the first byte the target sent. The password lives in a newtype whose `Debug` prints nothing, so printing a `Proxy` while debugging cannot spill it.
- `WebSocketBuilder::with_proxy`, on both the HTTP/1.1 and the HTTP/2 builder. The two client entry points duplicated the connect-then-TLS block, so that is folded into one `connect_stream`, and the builder options are passed down as a struct instead of growing another positional argument.
- `WebSocketError::Socks5`, carrying a typed `Socks5Error` with the RFC 1928 reply code in `ReplyCode`. I/O failures stay `IoError`.
- `--proxy` on yawcc, an `examples/socks5.rs`, and README, CHANGELOG and crate docs.

No new feature flag: the handshake is part of the native client and is always available. One new dependency, `percent-encoding`, for the URL userinfo, which `url` already pulls in.

### Testing

23 unit tests for URL parsing and the handshake over `tokio::io::duplex`, and 8 integration tests against a mock SOCKS5 server covering both schemes, a pinned address, authentication, a rejected password, a refused tunnel and the HTTP/2 path.

Also checked by hand against a throwaway SOCKS5 server and `wss://echo.websocket.org`: authenticated, remote DNS (`ATYP=3`) and local DNS (`ATYP=4`), TLS end to end. A wrong password gives `Socks5(AuthFailed(1))` and an unreachable target gives `Socks5(Rejected(ConnectionRefused))`.

`cargo fmt --check`, `cargo clippy -p yawc --lib --tests --examples` and the full suite are clean with and without `--features http2`, and the `wasm32-unknown-unknown` build still compiles.
